### PR TITLE
Add basic support for .bib files

### DIFF
--- a/bibtex/bibtex.ml
+++ b/bibtex/bibtex.ml
@@ -1,0 +1,223 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*  Copyright (C) 2017 Thomas Gazagnaire                                  *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+let src = Logs.Src.create "ramen.bib"
+module Log = (val Logs.src_log src: Logs.LOG)
+
+(*s Datatype for BibTeX bibliographies. *)
+
+include Types
+
+let dump_entry_type = Fmt.string
+let dump_key = Fmt.string
+
+let dump_atom ppf = function
+  | Id s     -> Fmt.pf ppf "@[Id %S@]" s
+  | String s -> Fmt.pf ppf "@[String %S@]" s
+
+let dump_atoms = Fmt.Dump.list dump_atom
+
+let dump_command ppf = function
+  | Comment s     -> Fmt.pf ppf "@[Comment %S@]" s
+  | Preamble a    -> Fmt.pf ppf "@[Preamble %a@]" dump_atoms a
+  | Abbrev (s, a) -> Fmt.pf ppf "@[Abbrev(%s,@ %a)@]" s dump_atoms a
+  | Entry (e,k,a) -> Fmt.pf ppf "@[Entry(%a,@ %a,@ %a)@]"
+                       dump_entry_type e
+                       dump_key k
+                       Fmt.(Dump.list (Dump.pair string dump_atoms)) a
+
+let dump = Fmt.vbox ~indent:2 (Fmt.Dump.list dump_command)
+
+let empty = []
+
+let size b = List.length b
+
+(*s the natural iterator on biblio must start at the first entry, so
+   it is the [fold_right] function on lists, NOT the [fold_left]! *)
+
+let fold = List.fold_right
+
+let add biblio command = command :: biblio
+
+module Abbrev: sig
+  type t
+  val v: unit -> t
+  val add: t -> string -> string -> unit
+  val find: t -> string -> string option
+end = struct
+
+  type t = (string, string) Hashtbl.t
+  let add t a s = Hashtbl.add t a s
+  let find t s =
+    try Some (Hashtbl.find t s)
+    with Not_found -> None
+
+  let v () =
+    let t = Hashtbl.create 97 in
+    (* months are predefined abbreviations *)
+    List.iter (fun (id,m) -> add t id m)
+      [ "jan", "January" ;
+        "feb", "February" ;
+        "mar", "March" ;
+        "apr", "April" ;
+        "may", "May" ;
+        "jun", "June" ;
+        "jul", "July" ;
+        "aug", "August" ;
+        "sep", "September" ;
+        "oct", "October" ;
+        "nov", "November" ;
+        "dec", "December" ];
+    t
+
+end
+
+type fields = (string * string) list
+
+type entry = entry_type * key * fields
+
+let expand_list abbrev l =
+  let rec aux acc = function
+    | []              -> String.concat "" (List.rev acc)
+    | String s :: rem -> aux (s :: acc) rem
+  | Id s     :: rem ->
+    let s = match Abbrev.find abbrev s with Some s -> s | None -> s in
+    aux (s :: acc) rem
+  in
+  Latex.to_html (aux [] l)
+
+let rec expand_fields t = function
+  | []           -> []
+  | (n,l) :: rem -> (n, expand_list t l) :: expand_fields t rem
+
+let macros_in_preamble s =
+  try
+    let lb = Lexing.from_string s in Latexscan.read_macros lb
+  with _ -> ()
+
+let expand abbrev (t: t): entry list =
+  fold (fun command accu ->
+      match command with
+      | Comment _       -> accu
+      | Entry (e, k, f) -> (e, k, expand_fields abbrev f) :: accu
+      | Preamble l ->
+        let s = expand_list abbrev l in
+        macros_in_preamble s;
+        accu
+      | Abbrev (a, l)   ->
+        let s = expand_list abbrev l in
+        Abbrev.add abbrev a s;
+        accu
+    ) t []
+
+module Date = struct
+
+  let int_of_month = function
+    | "Janvier" | "January" -> 0
+    | "Février" | "February" -> 1
+    | "Mars" | "March" -> 2
+    | "Avril" | "April" -> 3
+    | "Mai" | "May" -> 4
+    | "Juin" | "June" -> 5
+    | "Juillet" | "July" -> 6
+    | "Août" | "August" -> 7
+    | "Septembre" | "September" -> 8
+    | "Octobre" | "October" -> 9
+    | "Novembre" | "November" -> 10
+    | "Décembre" | "December" -> 11
+    | _ -> invalid_arg "int_of_month"
+
+  let month_day_re1 = Str.regexp "\\([a-zA-Z]+\\)\\( \\|~\\)\\([0-9]+\\)"
+  let month_day_re2 = Str.regexp "\\([0-9]+\\)\\( \\|~\\)\\([a-zA-Z]+\\)"
+  let month_anything = Str.regexp "\\([a-zA-Z]+\\)"
+
+  let parse_month a m =
+    if Str.string_match month_day_re1 m 0 then
+      int_of_month (Str.matched_group 1 m), int_of_string (Str.matched_group 3 m)
+    else if Str.string_match month_day_re2 m 0 then
+      int_of_month (Str.matched_group 3 m), int_of_string (Str.matched_group 1 m)
+    else if Str.string_match month_anything m 0 then
+      match Abbrev.find a (Str.matched_group 1 m) with
+      | Some m -> int_of_month m, 1
+      | None   ->
+        (* be Mendeley-friendly *)
+        int_of_month (Str.matched_group 1 m), 1
+    else
+      int_of_month m, 1
+
+
+  type date = { year : int; month : int; day : int }
+
+  let dummy_date = { year = 0; month = 0; day = 0 }
+
+  let extract_year k f =
+    try int_of_string (List.assoc "year" f)
+    with Failure _ ->
+      Log.warn (fun l -> l "Warning: incorrect year in entry %s" k);
+      0
+
+  let extract_month a f =
+    try parse_month a (List.assoc "month" f)
+    with Not_found | Failure _ ->
+      0, 1
+
+  let rec find_entry k = function
+    | [] -> raise Not_found
+    | (_,k',_) as e :: r -> if k = k' then e else find_entry k r
+
+  let rec extract_date a el (_,k,f) =
+    try
+      let y = extract_year k f in
+      let m,d = extract_month a f in
+      { year = y; month = m; day = d }
+    with Not_found ->
+    try extract_date a el (find_entry (List.assoc "crossref" f) el)
+    with Not_found -> dummy_date
+
+  let combine_comp c d =
+    if c=0 then d else c
+
+  let compare a el e1 e2 =
+    let d1 = extract_date a el e1 in
+    let d2 = extract_date a el e2 in
+    combine_comp
+      (d1.year - d2.year)
+      (combine_comp
+         (d1.month - d2.month)
+         (d1.day - d2.day))
+
+end
+
+let pp_position ppf lexbuf =
+  let open Lexing in
+  let pos = lexbuf.lex_curr_p in
+  Format.fprintf ppf "%s:%d:%d" pos.pos_fname
+    pos.pos_lnum (pos.pos_cnum - pos.pos_bol + 1)
+
+let of_string str =
+  let lb = Lexing.from_string str in
+  try Some (Parser.command_list Lexer.token lb)
+  with
+  | Parsing.Parse_error
+  | Failure _ ->
+    Log.err (fun l -> l "%a: syntax error\n%!" pp_position lb);
+    None
+
+let to_html_entries t =
+  let a = Abbrev.v () in
+  let t = expand a t in
+  List.sort (Date.compare a t) t

--- a/bibtex/bibtex.mli
+++ b/bibtex/bibtex.mli
@@ -1,0 +1,65 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*  Copyright (C) 2017 Thomas Gazagnaire                                  *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+(** A datatype for BibTeX bibliographies. *)
+
+type entry_type = string
+
+type key = string
+
+type atom =
+  | Id of string
+  | String of string
+
+type command =
+  | Comment of string
+  | Preamble of atom list
+  | Abbrev of string * atom list
+  | Entry  of entry_type * key * (string * atom list) list
+
+type t
+(** The type for bibliographies. *)
+
+val dump: t Fmt.t
+(** [dump] is the raw pretty-printer bibliographies. *)
+
+val empty: t
+(** [empty] is an empty bibliography *)
+
+val add: t -> command -> t
+(** [add b c] adds an entry [c] in the biblio [b] and returns the new
+    biblio. The [c] is supposed not to exists yet in [b]. *)
+
+val size: t -> int
+(** [size b] is the number of commands in [b] *)
+
+val fold: (command -> 'a -> 'a) -> t -> 'a -> 'a
+(** [fold f b accu] iterates [f] on the commands of [b], starting from
+    [a]. If the commands of [b] are $c_1,\ldots,c_n$ in this order,
+    then it computes $f ~ c_n ~ (f ~ c_{n-1} ~ \cdots ~ (f ~ c_1 ~
+    a)\cdots)$. *)
+
+val of_string: string -> t option
+(** [of_string s] parses the string [s] into a bibliography. *)
+
+(** {1 Expansion} *)
+
+type fields = (string * string) list
+
+type entry = entry_type * key * fields
+
+val to_html_entries: t -> entry list

--- a/bibtex/jbuild
+++ b/bibtex/jbuild
@@ -1,0 +1,9 @@
+(jbuild_version 1)
+
+(library
+  ((name        bibtex)
+   (libraries   (logs str fmt))))
+
+(ocamllex (lexer))
+(ocamllex (latexscan))
+(ocamlyacc (parser))

--- a/bibtex/latex.ml
+++ b/bibtex/latex.ml
@@ -1,0 +1,19 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+let to_html s =
+  Latexscan.brace_nesting := 0;
+  Fmt.to_to_string Latexscan.main (Lexing.from_string s)

--- a/bibtex/latex.mli
+++ b/bibtex/latex.mli
@@ -1,0 +1,17 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+val to_html: string -> string

--- a/bibtex/latexmacros.ml
+++ b/bibtex/latexmacros.ml
@@ -1,0 +1,747 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*  Copyright (C) 2017 Thomas Gazagnaire                                  *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+(* This code is an adaptation of a code written by Xavier Leroy in
+   1995-1997, in his own made latex2html translator. See
+
+   @inproceedings{Leroy-latex2html,
+               author =        "Xavier Leroy",
+               title =         "Lessons learned from the translation of
+                         documentation from \LaTeX\ to {HTML}",
+               booktitle =     "ERCIM/W4G Int. Workshop on WWW
+                         Authoring and Integration Tools",
+               year =          1995,
+               month =         feb}
+
+*)
+
+
+let src = Logs.Src.create "ramen.latex"
+module Log = (val Logs.src_log src: Logs.LOG)
+
+(*s Actions and translations table. *)
+
+type action =
+  | Print of string
+  | Print_arg
+  | Skip_arg
+  | Raw_arg of string Fmt.t
+  | Parameterized of (string -> action list)
+  | Recursive of string  (*r piece of LaTeX to analyze recursively *)
+
+let cmdtable = (Hashtbl.create 19 : (string, action list) Hashtbl.t)
+
+let def name action =
+  Hashtbl.add cmdtable name action
+
+let find_macro name =
+  try
+    Hashtbl.find cmdtable name
+  with Not_found ->
+    Log.err (fun l -> l "Unknown macro: %s\n" name);
+    []
+;;
+(*s Translations of general LaTeX macros. *)
+
+(* Sectioning *)
+def "\\part"
+  [Print "<H0>"; Print_arg; Print "</H0>\n"];
+def "\\chapter"
+  [Print "<H1>"; Print_arg; Print "</H1>\n"];
+def "\\chapter*"
+  [Print "<H1>"; Print_arg; Print "</H1>\n"];
+def "\\section"
+  [Print "<H2>"; Print_arg; Print "</H2>\n"];
+def "\\section*"
+  [Print "<H2>"; Print_arg; Print "</H2>\n"];
+def "\\subsection"
+  [Print "<H3>"; Print_arg; Print "</H3>\n"];
+def "\\subsection*"
+  [Print "<H3>"; Print_arg; Print "</H3>\n"];
+def "\\subsubsection"
+  [Print "<H4>"; Print_arg; Print "</H4>\n"];
+def "\\subsubsection*"
+  [Print "<H4>"; Print_arg; Print "</H4>\n"];
+def "\\paragraph"
+  [Print "<H5>"; Print_arg; Print "</H5>\n"];
+
+(* Text formatting *)
+def "\\begin{alltt}" [Print "<pre>"];
+def "\\end{alltt}" [Print "</pre>"];
+def "\\textbf" [Print "<b>" ; Print_arg ; Print "</b>"];
+def "\\mathbf" [Print "<b>" ; Print_arg ; Print "</b>"];
+def "\\texttt" [Print "<tt>" ; Print_arg ; Print "</tt>"];
+def "\\mathtt" [Print "<tt>" ; Print_arg ; Print "</tt>"];
+def "\\textit" [Print "<i>" ; Print_arg ; Print "</i>"];
+def "\\mathit" [Print "<i>" ; Print_arg ; Print "</i>"];
+def "\\textsl" [Print "<i>" ; Print_arg ; Print "</i>"];
+def "\\textem" [Print "<em>" ; Print_arg ; Print "</em>"];
+def "\\textrm" [Print_arg];
+def "\\mathrm" [Print_arg];
+def "\\textmd" [Print_arg];
+def "\\textup" [Print_arg];
+def "\\textnormal" [Print_arg];
+def "\\mathnormal" [Print "<i>" ; Print_arg ; Print "</i>"];
+def "\\mathcal" [Print_arg];
+def "\\mathbb" [Print_arg];
+def "\\mathfrak" [Print_arg];
+
+def "\\textin" [Print "<sub>"; Print_arg; Print "</sub>"];
+def "\\textsu" [Print "<sup>"; Print_arg; Print "</sup>"];
+def "\\textsuperscript" [Print "<sup>"; Print_arg; Print "</sup>"];
+def "\\textsi" [Print "<i>" ; Print_arg ; Print "</i>"];
+
+(* Basic color support. *)
+
+def "\\textcolor" [ Parameterized (function name ->
+  match String.lowercase_ascii name with
+  (* At the moment, we support only the 16 named colors defined in HTML 4.01. *)
+  | "black" | "silver" | "gray" | "white" | "maroon" | "red" | "purple" | "fuchsia"
+  | "green" | "lime" | "olive" | "yellow" | "navy" | "blue" | "teal" | "aqua" ->
+    [ Print (Printf.sprintf "<font color=%s>" name);
+      Print_arg ;
+      Print "</font>"
+    ]
+  (* Other, unknown colors have no effect. *)
+  | _ ->
+    [ Print_arg ]
+  )];
+
+(* Fonts without HTML equivalent *)
+def "\\textsf" [Print "<b>" ; Print_arg ; Print "</b>"];
+def "\\mathsf" [Print "<b>" ; Print_arg ; Print "</b>"];
+def "\\textsc" [Print_arg];
+
+def "\\textln" [Print_arg];
+def "\\textos" [Print_arg];
+def "\\textdf" [Print_arg];
+def "\\textsw" [Print_arg];
+
+def "\\rm" [];
+def "\\cal" [];
+def "\\emph" [Print "<em>" ; Print_arg ; Print "</em>"];
+def "\\mbox" [Print_arg];
+def "\\footnotesize" [];
+def "\\etalchar" [ Print "<sup>" ; Raw_arg Fmt.string ; Print "</sup>" ];
+def "\\newblock" [Print " "];
+
+(* Environments *)
+def "\\begin{itemize}" [Print "<p><ul>"];
+def "\\end{itemize}" [Print "</ul>"];
+def "\\begin{enumerate}" [Print "<p><ol>"];
+def "\\end{enumerate}" [Print "</ol>"];
+def "\\begin{description}" [Print "<p><dl>"];
+def "\\end{description}" [Print "</dl>"];
+def "\\begin{center}" [Print "<blockquote>"];
+def "\\end{center}" [Print "</blockquote>"];
+def "\\begin{htmlonly}" [];
+def "\\end{htmlonly}" [];
+def "\\begin{flushleft}" [Print "<blockquote>"];
+def "\\end{flushleft}" [Print "</blockquote>"];
+
+(* Special characters *)
+def "\\ " [Print " "];
+def "\\\n" [Print " "];
+def "\\{" [Print "{"];
+def "\\}" [Print "}"];
+def "\\l" [Print "l"];
+def "\\L" [Print "L"];
+def "\\oe" [Print "&oelig;"];
+def "\\OE" [Print "&OElig;"];
+def "\\o" [Print "&oslash;"];
+def "\\O" [Print "&Oslash;"];
+def "\\ae" [Print "&aelig;"];
+def "\\AE" [Print "&AElig;"];
+def "\\aa" [Print "&aring;"];
+def "\\AA" [Print "&Aring;"];
+def "\\i" [Print "i"];
+def "\\j" [Print "j"];
+def "\\&" [Print "&amp;"];
+def "\\$" [Print "$"];
+def "\\%" [Print "%"];
+def "\\_" [Print "_"];
+def "\\slash" [Print "/"];
+def "\\copyright" [Print "(c)"];
+def "\\th" [Print "&thorn;"];
+def "\\TH" [Print "&THORN;"];
+def "\\dh" [Print "&eth;"];
+def "\\DH" [Print "&ETH;"];
+def "\\dj" [Print "&#273;"];
+def "\\DJ" [Print "&#272;"];
+def "\\ss" [Print "&szlig;"];
+def "\\rq" [Print "&rsquo;"];
+def "\\'" [Raw_arg(function ppf -> function
+    | "e" -> Fmt.string ppf "&eacute;"
+    | "E" -> Fmt.string ppf "&Eacute;"
+    | "a" -> Fmt.string ppf "&aacute;"
+    | "A" -> Fmt.string ppf "&Aacute;"
+    | "o" -> Fmt.string ppf "&oacute;"
+    | "O" -> Fmt.string ppf "&Oacute;"
+    | "i" -> Fmt.string ppf "&iacute;"
+    | "\\i" -> Fmt.string ppf "&iacute;"
+    | "I" -> Fmt.string ppf "&Iacute;"
+    | "u" -> Fmt.string ppf "&uacute;"
+    | "U" -> Fmt.string ppf "&Uacute;"
+    | "'"  -> Fmt.string ppf "&rdquo;"
+    | "c" -> Fmt.string ppf "&#x107;"
+    | "C" -> Fmt.string ppf "&#x106;"
+    | "g" -> Fmt.string ppf "&#x1f5;"
+    | "G" -> Fmt.string ppf "G"
+    | "l" -> Fmt.string ppf "&#x13A;"
+    | "L" -> Fmt.string ppf "&#x139;"
+    | "n" -> Fmt.string ppf "&#x144;"
+    | "N" -> Fmt.string ppf "&#x143;"
+    | "r" -> Fmt.string ppf "&#x155;"
+    | "R" -> Fmt.string ppf "&#x154;"
+    | "s" -> Fmt.string ppf "&#x15b;"
+    | "S" -> Fmt.string ppf "&#x15a;"
+    | "y" -> Fmt.string ppf "&yacute;"
+    | "Y" -> Fmt.string ppf "&Yacute;"
+    | "z" -> Fmt.string ppf "&#x179;"
+    | "Z" -> Fmt.string ppf "&#x17a;"
+    | ""  -> Fmt.char   ppf  '\''
+    | s   -> Fmt.string ppf s)];
+def "\\`" [Raw_arg(function ppf -> function
+    | "e" -> Fmt.string ppf "&egrave;"
+    | "E" -> Fmt.string ppf "&Egrave;"
+    | "a" -> Fmt.string ppf "&agrave;"
+    | "A" -> Fmt.string ppf "&Agrave;"
+    | "o" -> Fmt.string ppf "&ograve;"
+    | "O" -> Fmt.string ppf "&Ograve;"
+    | "i" -> Fmt.string ppf "&igrave;"
+    | "\\i" -> Fmt.string ppf "&igrave;"
+    | "I" -> Fmt.string ppf "&Igrave;"
+    | "u" -> Fmt.string ppf "&ugrave;"
+    | "U" -> Fmt.string ppf "&Ugrave;"
+    | "`"  -> Fmt.string ppf "&ldquo;"
+    | ""  -> Fmt.string ppf "&lsquo;"
+    | s   -> Fmt.string ppf s)];
+def "\\~" [Raw_arg(function ppf -> function
+    | "n" -> Fmt.string ppf "&ntilde;"
+    | "N" -> Fmt.string ppf "&Ntilde;"
+    | "o" -> Fmt.string ppf "&otilde;"
+    | "O" -> Fmt.string ppf "&Otilde;"
+    | "i" -> Fmt.string ppf "&#x129;"
+    | "\\i" -> Fmt.string ppf "&#x129;"
+    | "I" -> Fmt.string ppf "&#x128;"
+    | "a" -> Fmt.string ppf "&atilde;"
+    | "A" -> Fmt.string ppf "&Atilde;"
+    | "u" -> Fmt.string ppf "&#169;"
+    | "U" -> Fmt.string ppf "&#168;"
+    | ""  -> Fmt.string ppf "&tilde;"
+    | s   -> Fmt.string ppf s)];
+def "\\k" [Raw_arg(function ppf -> function
+    | "A" -> Fmt.string ppf "&#260;"
+    | "a" -> Fmt.string ppf "&#261;"
+    | "i" -> Fmt.string ppf "&#302;"
+    | "I" -> Fmt.string ppf "&#303;"
+    | s   -> Fmt.string ppf s)];
+def "\\c" [Raw_arg(function ppf -> function
+    | "c" -> Fmt.string ppf "&ccedil;"
+    | "C" -> Fmt.string ppf "&Ccedil;"
+    | s   -> Fmt.string ppf s)];
+def "\\^" [Raw_arg(function ppf -> function
+    |"a" -> Fmt.string ppf "&acirc;"
+    | "A" -> Fmt.string ppf "&Acirc;"
+    | "e" -> Fmt.string ppf "&ecirc;"
+    | "E" -> Fmt.string ppf "&Ecirc;"
+    | "i" -> Fmt.string ppf "&icirc;"
+    | "\\i" -> Fmt.string ppf "&icirc;"
+    | "I" -> Fmt.string ppf "&Icirc;"
+    | "o" -> Fmt.string ppf "&ocirc;"
+    | "O" -> Fmt.string ppf "&Ocirc;"
+    | "u" -> Fmt.string ppf "&ucirc;"
+    | "U" -> Fmt.string ppf "&Ucirc;"
+    | "w" -> Fmt.string ppf "&#x175;"
+    | "W" -> Fmt.string ppf "&#x174;"
+    | "y" -> Fmt.string ppf "&#x177;"
+    | "Y" -> Fmt.string ppf "&#x176;"
+    | ""  -> Fmt.char   ppf '^'
+    | s   -> Fmt.string ppf s)];
+def "\\hat" [Raw_arg(function ppf -> function
+    | "a" -> Fmt.string ppf "<em>&acirc;</em>"
+    | "A" -> Fmt.string ppf "<em>&Acirc;</em>"
+    | "e" -> Fmt.string ppf "<em>&ecirc;</em>"
+    | "E" -> Fmt.string ppf "<em>&Ecirc;</em>"
+    | "i" -> Fmt.string ppf "<em>&icirc;</em>"
+    | "\\i" -> Fmt.string ppf "<em>&icirc;</em>"
+    | "I" -> Fmt.string ppf "<em>&Icirc;</em>"
+    | "o" -> Fmt.string ppf "<em>&ocirc;</em>"
+    | "O" -> Fmt.string ppf "<em>&Ocirc;</em>"
+    | "u" -> Fmt.string ppf "<em>&ucirc;</em>"
+    | "U" -> Fmt.string ppf "<em>&Ucirc;</em>"
+    | ""  -> Fmt.char   ppf '^'
+    | s   -> Fmt.string ppf s)];
+def "\\\"" [Raw_arg(function ppf -> function
+    | "e" -> Fmt.string ppf "&euml;"
+    | "E" -> Fmt.string ppf "&Euml;"
+    | "a" -> Fmt.string ppf "&auml;"
+    | "A" -> Fmt.string ppf "&Auml;"
+    | "\\i" -> Fmt.string ppf "&iuml;"
+    | "i" -> Fmt.string ppf "&iuml;"
+    | "I" -> Fmt.string ppf "&Iuml;"
+    | "o" -> Fmt.string ppf "&ouml;"
+    | "O" -> Fmt.string ppf "&Ouml;"
+    | "u" -> Fmt.string ppf "&uuml;"
+    | "U" -> Fmt.string ppf "&Uuml;"
+    | "y" -> Fmt.string ppf "&yuml;"
+    | "Y" -> Fmt.string ppf "&Yuml;"
+    | s   -> Fmt.string ppf s)];
+def "\\d" [Raw_arg Fmt.string ];
+def "\\." [Raw_arg (function ppf -> function
+    | "a" -> Fmt.string ppf "&#x227;"
+    | "A" -> Fmt.string ppf "&#x226;"
+    | "c" -> Fmt.string ppf "&#x10b;"
+    | "C" -> Fmt.string ppf "&#x10a;"
+    | "e" -> Fmt.string ppf "&#279;"
+    | "E" -> Fmt.string ppf "&#278;"
+    | "g" -> Fmt.string ppf "&#289;"
+    | "G" -> Fmt.string ppf "&#288;"
+    | "i" -> Fmt.string ppf "i"
+    | "\\i" -> Fmt.string ppf "i"
+    | "I" -> Fmt.string ppf "&#304;"
+    | "o" -> Fmt.string ppf "&#559;"
+    | "O" -> Fmt.string ppf "&#558;"
+    | "z" -> Fmt.string ppf "&#380;"
+    | "Z" -> Fmt.string ppf "&#379;"
+    | s   -> Fmt.string ppf s)];
+def "\\u" [Raw_arg(function  ppf -> function
+    | "a" -> Fmt.string ppf "&#x103;"
+    | "A" -> Fmt.string ppf "&#x102;"
+    | "e" -> Fmt.string ppf "&#x115;"
+    | "E" -> Fmt.string ppf "&#x114;"
+    | "i" -> Fmt.string ppf "&#x12C;"
+    | "\\i" -> Fmt.string ppf "&#x12C;"
+    | "I" -> Fmt.string ppf "&#x12D;"
+    | "g" -> Fmt.string ppf "&#x11F;"
+    | "G" -> Fmt.string ppf "&#x11E;"
+    | "o" -> Fmt.string ppf "&#x14F;"
+    | "O" -> Fmt.string ppf "&#x14E;"
+    | "u" -> Fmt.string ppf "&#x16D;"
+    | "U" -> Fmt.string ppf "&#x16C;"
+    | s   -> Fmt.string ppf s)];
+def "\\v" [Raw_arg(function ppf -> function
+    | "C" -> Fmt.string ppf "&#x010C;"
+    | "c" -> Fmt.string ppf "&#x010D;"
+    | "D" -> Fmt.string ppf "&#270;"
+    | "d" -> Fmt.string ppf "&#271;"
+    | "E" -> Fmt.string ppf "&#282;"
+    | "e" -> Fmt.string ppf "&#283;"
+    | "N" -> Fmt.string ppf "&#327;"
+    | "n" -> Fmt.string ppf "&#328;"
+    | "r" -> Fmt.string ppf "&#X0159;"
+    | "R" -> Fmt.string ppf "&#X0158;"
+    | "s" -> Fmt.string ppf "&scaron;" (*"&#X0161;"*)
+    | "S" -> Fmt.string ppf "&Scaron;" (*"&#X0160;"*)
+    | "T" -> Fmt.string ppf "&#356;"
+    | "t" -> Fmt.string ppf "&#357;"
+    | "\\i" -> Fmt.string ppf "&#X012D;"
+    | "i" -> Fmt.string ppf "&#X012D;"
+    | "I" -> Fmt.string ppf "&#X012C;"
+    | "Z" -> Fmt.string ppf "&#381;"
+    | "z" -> Fmt.string ppf "&#382;"
+    | s   -> Fmt.string ppf s)];
+def "\\H" [Raw_arg (function ppf -> function
+    | "O" -> Fmt.string ppf "&#336;"
+    | "o" -> Fmt.string ppf "&#337;"
+    | "U" -> Fmt.string ppf "&#368;"
+    | "u" -> Fmt.string ppf "&#369;"
+    | s -> Fmt.string ppf s)];
+def "\\r" [Raw_arg (function ppf -> function
+    | "U" -> Fmt.string ppf "&#366;"
+    | "u" -> Fmt.string ppf "&#367;"
+    | s -> Fmt.string ppf s)];
+
+(* Math macros *)
+def "\\[" [Print "<blockquote>"];
+def "\\]" [Print "\n</blockquote>"];
+def "\\le" [Print "&lt;="];
+def "\\leq" [Print "&lt;="];
+def "\\log" [Print "log"];
+def "\\ge" [Print "&gt;="];
+def "\\geq" [Print "&gt;="];
+def "\\neq" [Print "&lt;&gt;"];
+def "\\circ" [Print "o"];
+def "\\bigcirc" [Print "O"];
+def "\\sim" [Print "~"];
+def "\\(" [Print "<I>"];
+def "\\)" [Print "</I>"];
+def "\\mapsto" [Print "<tt>|-&gt;</tt>"];
+def "\\times" [Print "&#215;"];
+def "\\neg" [Print "&#172;"];
+def "\\frac" [Print "("; Print_arg; Print ")/("; Print_arg; Print ")"];
+def "\\not" [Print "not "];
+
+(* Math symbols printed as texts (could we do better?) *)
+def "\\ne" [Print "=/="];
+def "\\in" [Print "in"];
+def "\\forall" [Print "for all"];
+def "\\exists" [Print "there exists"];
+def "\\vdash" [Print "|-"];
+def "\\ln" [Print "ln"];
+def "\\gcd" [Print "gcd"];
+def "\\min" [Print "min"];
+def "\\max" [Print "max"];
+def "\\exp" [Print "exp"];
+def "\\rightarrow" [Print "-&gt;"];
+def "\\to" [Print "-&gt;"];
+def "\\longrightarrow" [Print "--&gt;"];
+def "\\Rightarrow" [Print "=&gt;"];
+def "\\leftarrow" [Print "&lt;-"];
+def "\\longleftarrow" [Print "&lt;--"];
+def "\\Leftarrow" [Print "&lt;="];
+def "\\leftrightarrow" [Print "&lt;-&gt;"];
+def "\\sqrt" [Print "sqrt("; Print_arg; Print ")"];
+def "\\vee" [Print "V"];
+def "\\lor" [Print "V"];
+def "\\wedge" [Print "/\\"];
+def "\\land" [Print "/\\"];
+def "\\Vert" [Print "||"];
+def "\\parallel" [Print "||"];
+def "\\mid" [Print "|"];
+def "\\cup" [Print "U"];
+def "\\inf" [Print "inf"];
+
+(* Misc. macros. *)
+def "\\TeX" [Print "T<sub>E</sub>X"];
+def "\\LaTeX" [Print "L<sup>A</sup>T<sub>E</sub>X"];
+def "\\LaTeXe"
+  [Print "L<sup>A</sup>T<sub>E</sub>X&nbsp;2<FONT FACE=symbol>e</FONT>"];
+def "\\tm" [Print "<sup><font size=-1>TM</font></sup>"];
+def "\\par" [Print "<p>"];
+def "\\@" [Print " "];
+def "\\#" [Print "#"];
+def "\\/" [];
+def "\\-" [];
+def "\\left" [];
+def "\\right" [];
+def "\\smallskip" [];
+def "\\medskip" [];
+def "\\bigskip" [];
+def "\\relax" [];
+def "\\markboth" [Skip_arg; Skip_arg];
+def "\\dots" [Print "..."];
+def "\\dot" [Print "."];
+def "\\simeq" [Print "&tilde;="];
+def "\\approx" [Print "&tilde;"];
+def "\\^circ" [Print "&deg;"];
+def "\\ldots" [Print "..."];
+def "\\cdot" [Print "&#183;"];
+def "\\cdots" [Print "..."];
+def "\\newpage" [];
+def "\\hbox" [Print_arg];
+def "\\noindent" [];
+def "\\label" [Print "<A name=\""; Print_arg; Print "\"></A>"];
+def "\\ref" [Print "<A href=\"#"; Print_arg; Print "\">(ref)</A>"];
+def "\\index" [Skip_arg];
+def "\\\\" [Print "<br>"];
+def "\\," [];
+def "\\;" [];
+def "\\!" [];
+def "\\hspace" [Skip_arg; Print " "];
+def "\\symbol"
+  [Raw_arg (fun ppf s ->
+     try let n = int_of_string s in Fmt.char ppf (Char.chr n)
+     with _ -> ())];
+def "\\html" [Raw_arg Fmt.string];
+def "\\textcopyright" [Print "&copy;"];
+def "\\textordfeminine" [Print "&ordf;"];
+def "\\textordmasculine" [Print "&ordm;"];
+def "\\backslash" [Print "&#92;"];
+
+
+(* hyperref *)
+def "\\href"
+  [Print "<a href=\""; Raw_arg Fmt.string;
+   Print "\">"; Print_arg; Print "</a>"];
+
+(* Bibliography *)
+def "\\begin{thebibliography}" [Print "<H2>References</H2>\n<dl>\n"; Skip_arg];
+def "\\end{thebibliography}" [Print "</dl>"];
+def "\\bibitem" [Raw_arg (fun ppf r ->
+    Fmt.string ppf "<dt><A name=\""; Fmt.string ppf r; Fmt.string ppf "\">[";
+    Fmt.string ppf r; Fmt.string ppf "]</A>\n";
+    Fmt.string ppf "<dd>")];
+
+(* Greek letters *)
+(***
+   List.iter
+   (fun symbol -> def ("\\" ^ symbol) [Print ("<EM>" ^ symbol ^ "</EM>")])
+   ["alpha";"beta";"gamma";"delta";"epsilon";"varepsilon";"zeta";"eta";
+   "theta";"vartheta";"iota";"kappa";"lambda";"mu";"nu";"xi";"pi";"varpi";
+   "rho";"varrho";"sigma";"varsigma";"tau";"upsilon";"phi";"varphi";
+   "chi";"psi";"omega";"Gamma";"Delta";"Theta";"Lambda";"Xi";"Pi";
+   "Sigma";"Upsilon";"Phi";"Psi";"Omega"];
+ ***)
+def "\\alpha" [Print "&alpha;"];
+def "\\beta" [Print "&beta;"];
+def "\\gamma" [Print "&gamma;"];
+def "\\delta" [Print "&delta;"];
+def "\\epsilon" [Print "&epsilon;"];
+def "\\varepsilon" [Print "&epsilon;"];
+def "\\zeta" [Print "&zeta;"];
+def "\\eta" [Print "&eta;"];
+def "\\theta" [Print "&theta;"];
+def "\\vartheta" [Print "&theta;"];
+def "\\iota" [Print "&iota;"];
+def "\\kappa" [Print "&kappa;"];
+def "\\lambda" [Print "&lambda;"];
+def "\\mu" [Print "&mu;"];
+def "\\nu" [Print "&nu;"];
+def "\\xi" [Print "&xi;"];
+def "\\pi" [Print "&pi;"];
+def "\\varpi" [Print "&piv;"];
+def "\\rho" [Print "&rho;"];
+def "\\varrho" [Print "&rho;"];
+def "\\sigma" [Print "&sigma;"];
+def "\\varsigma" [Print "&sigmaf;"];
+def "\\tau" [Print "&tau;"];
+def "\\upsilon" [Print "&upsilon;"];
+def "\\phi" [Print "&phi;"];
+def "\\varphi" [Print "&phi;"];
+def "\\chi" [Print "&chi;"];
+def "\\psi" [Print "&psi;"];
+def "\\omega" [Print "&omega;"];
+def "\\Gamma" [Print "&Gamma;"];
+def "\\Delta" [Print "&Delta;"];
+def "\\Theta" [Print "&Theta;"];
+def "\\Lambda" [Print "&Lambda;"];
+def "\\Xi" [Print "&Xi;"];
+def "\\Pi" [Print "&Pi;"];
+def "\\Sigma" [Print "&Sigma;"];
+def "\\Upsilon" [Print "&Upsilon;"];
+def "\\Phi" [Print "&Phi;"];
+def "\\Psi" [Print "&Psi;"];
+def "\\Omega" [Print "&Omega;"];
+
+
+(* macros for the AMS styles *)
+
+def "\\bysame" [Print "<u>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</u>"];
+def "\\MR"
+  [Raw_arg (fun ppf s ->
+       let mr =
+         try
+           let i = String.index s ' ' in
+           if i=0 then raise Not_found;
+           String.sub s 0 i
+         with Not_found -> s
+       in
+       Fmt.string ppf "<a href=\"http://www.ams.org/mathscinet-getitem?mr=";
+       Fmt.string ppf mr;
+       Fmt.string ppf "\">MR ";
+       Fmt.string ppf s;
+       Fmt.string ppf "</a>")];
+def "\\MRhref"
+  [Print "<a href=\"http://www.ams.org/mathscinet-getitem?mr=";
+   Print_arg; Print "\">"; Print_arg; Print "</a>"];
+
+(* macros for the aaai-named style *)
+
+def "\\em" [];
+def "\\protect" [];
+def "\\bgroup" []; (* should go into latexscan? *)
+def "\\egroup" []; (* should go into latexscan? *)
+def "\\citename" [];
+
+(* dashes *)
+def "--" [Print "--"];
+def "---" [Print "---"];
+
+()
+
+(* Unicode entities *)
+
+let unicode_entities () =
+  def "\\models" [Print "&#X22A8;"];
+  def "\\curlyvee" [Print "&#X22CE;"];
+  def "\\curlywedge" [Print "&#X22CF"];
+  def "\\bigcirc" [Print "&#9711;"];
+  def "\\varepsilon" [Print "&#603;"];
+  def "\\not" [Raw_arg (function ppf -> function
+      | "\\models" -> Fmt.string ppf "&#8877;"
+      | s -> Fmt.string ppf "not "; Fmt.string ppf s)];
+  def "--" [Print "&#x2013;"];
+  def "---" [Print "&#x2014;"];
+  ()
+
+let html_entities () =
+  def "\\sqrt" [Print "&radic;("; Print_arg; Print ")"];
+  def "\\copyright" [Print "&copy;"];
+  def "\\tm" [Print "&trade;"];
+  def "\\lang" [Print "&lang;"];
+  def "\\rang" [Print "&rang;"];
+  def "\\lceil" [Print "&lceil;"];
+  def "\\rceil" [Print "&rceil;"];
+  def "\\lfloor" [Print "&lfloor;"];
+  def "\\rfloor" [Print "&rfloor;"];
+  def "\\le" [Print "&le;"];
+  def "\\leq" [Print "&le;"];
+  def "\\ge" [Print "&ge;"];
+  def "\\geq" [Print "&ge;"];
+  def "\\neq" [Print "&ne;"];
+  def "\\approx" [Print "&asymp;"];
+  def "\\cong" [Print "&cong;"];
+  def "\\equiv" [Print "&equiv;"];
+  def "\\propto" [Print "&prop;"];
+  def "\\subset" [Print "&sub;"];
+  def "\\subseteq" [Print "&sube;"];
+  def "\\supset" [Print "&sup;"];
+  def "\\supseteq" [Print "&supe;"];
+  def "\\ang" [Print "&ang;"];
+  def "\\perp" [Print "&perp;"];
+  def "\\therefore" [Print "&there4;"];
+  def "\\sim" [Print "&sim;"];
+  def "\\times" [Print "&times;"];
+  def "\\ast" [Print "&lowast;"];
+  def "\\otimes" [Print "&otimes;"];
+  def "\\oplus" [Print "&oplus;"];
+  def "\\lozenge" [Print "&loz;"];
+  def "\\diamond" [Print "&loz;"];
+  def "\\neg" [Print "&not;"];
+  def "\\pm" [Print "&plusmn;"];
+  def "\\dagger" [Print "&dagger;"];
+  def "\\ne" [Print "&ne;"];
+  def "\\in" [Print "&isin;"];
+  def "\\notin" [Print "&notin;"];
+  def "\\ni" [Print "&ni;"];
+  def "\\forall" [Print "&forall;"];
+  def "\\exists" [Print "&exist;"];
+  def "\\Re" [Print "&real;"];
+  def "\\Im" [Print "&image;"];
+  def "\\aleph" [Print "&alefsym;"];
+  def "\\wp" [Print "&weierp;"];
+  def "\\emptyset" [Print "&empty;"];
+  def "\\nabla" [Print "&nabla;"];
+  def "\\rightarrow" [Print "&rarr;"];
+  def "\\to" [Print "&rarr;"];
+  def "\\longrightarrow" [Print "&rarr;"];
+  def "\\Rightarrow" [Print "&rArr;"];
+  def "\\leftarrow" [Print "&larr;"];
+  def "\\longleftarrow" [Print "&larr;"];
+  def "\\Leftarrow" [Print "&lArr;"];
+  def "\\leftrightarrow" [Print "&harr;"];
+  def "\\sum" [Print "&sum;"];
+  def "\\prod" [Print "&prod;"];
+  def "\\int" [Print "&int;"];
+  def "\\partial" [Print "&part;"];
+  def "\\vee" [Print "&or;"];
+  def "\\lor" [Print "&or;"];
+  def "\\wedge" [Print "&and;"];
+  def "\\land" [Print "&and;"];
+  def "\\cup" [Print "&cup;"];
+  def "\\infty" [Print "&infin;"];
+  def "\\simeq" [Print "&cong;"];
+  def "\\cdot" [Print "&sdot;"];
+  def "\\cdots" [Print "&sdot;&sdot;&sdot;"];
+  def "\\vartheta" [Print "&thetasym;"];
+  def "\\angle" [Print "&ang;"];
+  def "\\=" [Raw_arg(function ppf -> function
+      | "a" -> Fmt.string ppf "&abar;"
+      | "A" -> Fmt.string ppf "&Abar;"
+      | s   -> Fmt.string ppf s)];
+  def "--" [Print "&ndash;"];
+  def "---" [Print "&mdash;"];
+  ()
+
+(*s Macros for German BibTeX style. *)
+
+let is_german_style = function
+  | "gerabbrv" | "geralpha" | "gerapali" | "gerplain" | "gerunsrt" -> true
+  | _ -> false
+
+let init_style_macros st =
+  if is_german_style st then begin
+    List.iter (fun (m,s) -> def m [ Print s; Print_arg ])
+      [ "\\btxetalshort", "et al" ;
+        "\\btxeditorshort", "Hrsg";
+        "\\Btxeditorshort", "Hrsg";
+        "\\btxeditorsshort", "Hrsg";
+        "\\Btxeditorsshort", "Hrsg";
+        "\\btxvolumeshort", "Bd";
+        "\\Btxvolumeshort", "Bd";
+        "\\btxnumbershort", "Nr";
+        "\\Btxnumbershort", "Nr";
+        "\\btxeditionshort", "Aufl";
+        "\\Btxeditionshort", "Aufl";
+        "\\btxchaptershort", "Kap";
+        "\\Btxchaptershort", "Kap";
+        "\\btxpageshort", "S";
+        "\\Btxpageshort", "S";
+        "\\btxpagesshort", "S";
+        "\\Btxpagesshort", "S";
+        "\\btxtechrepshort", "Techn. Ber";
+        "\\Btxtechrepshort", "Techn. Ber";
+        "\\btxmonjanshort", "Jan";
+        "\\btxmonfebshort", "Feb";
+        "\\btxmonaprshort", "Apr";
+        "\\btxmonaugshort", "Aug";
+        "\\btxmonsepshort", "Sep";
+        "\\btxmonoctshort", "Okt";
+        "\\btxmonnovshort", "Nov";
+        "\\btxmondecshort", "Dez";
+      ];
+    List.iter (fun (m,s) -> def m [ Skip_arg; Print s])
+      [ "\\btxetallong", "et alii";
+        "\\btxandshort", "und";
+        "\\btxandlong", "und";
+        "\\btxinlong", "in:";
+        "\\btxinshort", "in:";
+        "\\btxofseriesshort", "d. Reihe";
+        "\\btxinseriesshort", "in";
+        "\\btxofserieslong", "der Reihe";
+        "\\btxinserieslong", "in";
+        "\\btxeditorlong", "Herausgeber";
+        "\\Btxeditorlong", "Herausgeber";
+        "\\btxeditorslong", "Herausgeber";
+        "\\Btxeditorslong", "Herausgeber";
+        "\\btxvolumelong", "Band";
+        "\\Btxvolumelong", "Band";
+        "\\btxnumberlong", "Nummer";
+        "\\Btxnumberlong", "Nummer";
+        "\\btxeditionlong", "Auflage";
+        "\\Btxeditionlong", "Auflage";
+        "\\btxchapterlong", "Kapitel";
+        "\\Btxchapterlong", "Kapitel";
+        "\\btxpagelong", "Seite";
+        "\\Btxpagelong", "Seite";
+        "\\btxpageslong", "Seiten";
+        "\\Btxpageslong", "Seiten";
+        "\\btxmastthesis", "Diplomarbeit";
+        "\\btxphdthesis", "Doktorarbeit";
+        "\\btxtechreplong", "Technischer Bericht";
+        "\\Btxtechreplong", "Technischer Bericht";
+        "\\btxmonjanlong", "Januar";
+        "\\btxmonfeblong", "Februar";
+        "\\btxmonmarlong", "März";
+        "\\btxmonaprlong", "April";
+        "\\btxmonmaylong", "Mai";
+        "\\btxmonjunlong", "Juni";
+        "\\btxmonjullong", "Juli";
+        "\\btxmonauglong", "August";
+        "\\btxmonseplong", "September";
+        "\\btxmonoctlong", "Oktober";
+        "\\btxmonnovlong", "November";
+        "\\btxmondeclong", "Dezember";
+        "\\btxmonmarshort", "März";
+        "\\btxmonmayshort", "Mai";
+        "\\btxmonjunshort", "Juni";
+        "\\btxmonjulshort", "Juli";
+        "\\Btxinlong", "In:";
+        "\\Btxinshort", "In:";
+      ]
+  end

--- a/bibtex/latexmacros.mli
+++ b/bibtex/latexmacros.mli
@@ -1,0 +1,53 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+(*s This module provides a table to store the translations of LaTeX
+  macros. A translation is a list of actions of the following type
+  [action]. *)
+
+(* This code is an adaptation of a code written by Xavier Leroy in
+   1995-1997, in his own home-made latex2html translator. See
+
+   @inproceedings{Leroy-latex2html,
+               author =        "Xavier Leroy",
+               title =         "Lessons learned from the translation of
+                         documentation from \LaTeX\ to {HTML}",
+               booktitle =     "ERCIM/W4G Int. Workshop on WWW
+                         Authoring and Integration Tools",
+               year =          1995,
+               month =         feb}
+
+*)
+
+type action =
+  | Print of string
+  | Print_arg
+  | Skip_arg
+  | Raw_arg of string Fmt.t
+  | Parameterized of (string -> action list)
+  | Recursive of string
+
+val def : string -> action list -> unit
+
+val find_macro: string -> action list
+
+val init_style_macros : string -> unit
+
+(*s HTML entities *)
+
+val html_entities : unit -> unit
+
+val unicode_entities : unit -> unit

--- a/bibtex/latexscan.mll
+++ b/bibtex/latexscan.mll
@@ -1,0 +1,371 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+(*
+ * bibtex2html - A BibTeX to HTML translator
+ * Copyright (C) 1997 Jean-Christophe FILLIATRE
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License version 2 for more details
+ * (enclosed in the file GPL).
+ *)
+
+(*i $Id: latexscan.mll,v 1.40 2010-02-22 07:38:19 filliatr Exp $ i*)
+
+(*s This code is Copyright (C) 1997 Xavier Leroy. *)
+
+{
+
+let src = Logs.Src.create "ramen.latex"
+module Log = (val Logs.src_log src: Logs.LOG)
+
+open Latexmacros
+
+type math_mode = MathNone | MathDisplay | MathNoDisplay
+
+let brace_nesting = ref 0
+let math_mode = ref MathNone
+
+let is_math_mode () =
+  match !math_mode with
+  | MathNone -> false
+  | MathDisplay | MathNoDisplay -> true
+
+let hevea_url = ref false
+let html_entities = ref false
+
+let save_nesting f arg =
+  let n = !brace_nesting in
+  brace_nesting := 0;
+  f arg;
+  brace_nesting := n
+
+let save_state f arg =
+  let n = !brace_nesting and m = !math_mode in
+  brace_nesting := 0;
+  math_mode := MathNone;
+  f arg;
+  brace_nesting := n;
+  math_mode := m
+
+let verb_delim = ref (Char.chr 0)
+
+let r = Str.regexp "[ \t\n]+"
+let remove_whitespace u = Str.global_replace r "" u
+
+let amp = Str.regexp_string "&"
+let url s = Str.global_replace amp "&amp;" s
+
+let print_latex_url ppf u =
+  let u = url (remove_whitespace u) in
+  Fmt.pf ppf "<a href=\"%s\">%s</a>" u u
+
+let print_hevea_url ppf u t =
+  let u = url (remove_whitespace u) in
+  Fmt.pf ppf "<a href=\"%s\">%s</a>" u t
+
+let chop_last_space s =
+  let n = String.length s in
+  if s.[n-1] = ' ' then String.sub s 0 (n-1) else s
+
+let def_macro s n b =
+  Log.debug (fun l -> l "macro: %s = %s\n" s b);
+  let n = match n with None -> 0 | Some n -> int_of_string n in
+  let rec code i subst =
+    if i <= n then
+      let r = Str.regexp ("#" ^ string_of_int i) in
+      [Parameterized
+         (fun arg ->
+            let subst s = Str.global_replace r (subst s) arg in
+            code (i+1) subst)]
+    else begin
+      let _s = subst b in
+      (* eprintf "subst b = %s\n" s; flush stderr; *)
+      [Recursive (subst b)]
+    end
+  in
+  def s (code 1 (fun s -> s))
+
+let exec_macro ppf ~main ~print_arg ~raw_arg ~skip_arg lexbuf m =
+  let rec exec = function
+    | Print str -> Fmt.string ppf str
+    | Print_arg -> print_arg ppf lexbuf
+    | Raw_arg f -> let s = raw_arg lexbuf in f ppf s
+    | Skip_arg -> save_nesting skip_arg lexbuf
+    | Recursive s -> main ppf (Lexing.from_string s)
+    | Parameterized f -> List.iter exec (f (raw_arg lexbuf))
+  in List.iter exec (find_macro m)
+}
+
+let space = [' ' '\t' '\n' '\r']
+let float = '-'? (['0'-'9']+ | ['0'-'9']* '.' ['0'-'9']*)
+let dimension = float ("sp" | "pt" | "bp" | "dd" | "mm" | "pc" |
+                       "cc" | "cm" | "in" | "ex" | "em" | "mu")
+
+rule main ppf = parse
+(* Comments *)
+    '%' [^ '\n'] * '\n' { main ppf lexbuf }
+(* Paragraphs *)
+  | "\n\n" '\n' *
+                { Fmt.string ppf "<p>\n"; main ppf lexbuf }
+(* Font changes *)
+  | "{\\it" " "* | "{\\itshape" " "*
+                  { Fmt.string ppf "<i>";
+                    save_state (main ppf)lexbuf;
+                    Fmt.string ppf "</i>"; main ppf lexbuf }
+  | "{\\em" " "* | "{\\sl" " "* | "{\\slshape" " "*
+                  { Fmt.string ppf "<em>";
+                    save_state (main ppf) lexbuf;
+                    Fmt.string ppf "</em>"; main ppf lexbuf }
+  | "{\\bf" " "* | "{\\sf" " "* | "{\\bfseries" " "* | "{\\sffamily" " "*
+                  { Fmt.string ppf "<b>";
+                    save_state (main ppf) lexbuf;
+                    Fmt.string ppf "</b>"; main ppf lexbuf }
+  | "{\\sc" " "*  | "{\\scshape" " "* | "{\\normalfont" " "*
+  | "{\\upshape" " "* | "{\\mdseries" " "* | "{\\rmfamily" " "*
+                  { save_state (main ppf) lexbuf; main ppf lexbuf }
+  | "{\\tt" " "* | "{\\ttfamily" " "*
+                  { Fmt.string ppf "<tt>";
+                    save_state (main ppf) lexbuf;
+                    Fmt.string ppf "</tt>"; main ppf lexbuf }
+  | "{\\small" " "*
+                  { Fmt.string ppf "<font size=\"-1\">";
+                    save_state (main ppf) lexbuf;
+                    Fmt.string ppf "</font>"; main ppf lexbuf }
+  | "{\\rm" " "*
+                  { Fmt.string ppf "<span style=\"font-style: normal\">";
+                    save_state (main ppf) lexbuf;
+                    Fmt.string ppf "</span>"; main ppf lexbuf }
+  | "{\\cal" " "*
+                  { save_state (main ppf) lexbuf; main ppf lexbuf }
+  | "\\cal" " "*  { main ppf lexbuf }
+(* Double quotes *)
+(***
+  | '"'           { Fmt.string ppf "<tt>"; indoublequote lexbuf;
+                    Fmt.string ppf "</tt>"; main ppf lexbuf }
+***)
+(* Verb, verbatim *)
+  | ("\\verb" | "\\path") _
+                { verb_delim := Lexing.lexeme_char lexbuf 5;
+                  Fmt.string ppf "<tt>";
+                  inverb ppf lexbuf;
+                  Fmt.string ppf "</tt>";
+                  main ppf lexbuf }
+  | "\\begin{verbatim}"
+                { Fmt.string ppf "<pre>"; inverbatim ppf lexbuf;
+                  Fmt.string ppf "</pre>"; main ppf lexbuf }
+(* Raw html, latex only *)
+  | "\\begin{rawhtml}"
+                { rawhtml ppf lexbuf; main ppf lexbuf }
+  | "\\begin{latexonly}"
+                { latexonly lexbuf; main ppf lexbuf }
+(* Itemize and similar environments *)
+  | "\\item[" [^ ']']* "]"
+                { Fmt.string ppf "<dt>";
+                  let s = Lexing.lexeme lexbuf in
+                  Fmt.string ppf (String.sub s 6 (String.length s - 7));
+                  Fmt.string ppf "<dd>"; main ppf lexbuf }
+  | "\\item"    { Fmt.string ppf "<li>"; main ppf lexbuf }
+(* Math mode (hmph) *)
+  | "$"         { math_mode :=
+                    begin
+                      match !math_mode with
+                        | MathNone -> MathNoDisplay
+                        | MathNoDisplay -> MathNone
+                        | MathDisplay -> (* syntax error *) MathNone
+                    end;
+                  main ppf lexbuf }
+  | "$$"        { math_mode :=
+                    begin
+                      match !math_mode with
+                        | MathNone ->
+                            Fmt.string ppf "<blockquote>";
+                            MathDisplay
+                        | MathNoDisplay -> MathNoDisplay
+                        | MathDisplay ->
+                            Fmt.string ppf "\n</blockquote>";
+                            MathNone
+                    end;
+                  main ppf lexbuf }
+(* \hkip *)
+  | "\\hskip" space* dimension
+    (space* "plus" space* dimension)? (space* "minus" space* dimension)?
+                { Fmt.string ppf " "; main ppf lexbuf }
+(* Special characters *)
+  | "\\char" ['0'-'9']+
+                { let lxm = Lexing.lexeme lexbuf in
+                  let code = String.sub lxm 5 (String.length lxm - 5) in
+                  Fmt.char ppf (Char.chr(int_of_string code));
+                  main ppf lexbuf }
+  | "<"         { Fmt.string ppf "&lt;"; main ppf lexbuf }
+  | ">"         { Fmt.string ppf "&gt;"; main ppf lexbuf }
+  | "~"         { Fmt.string ppf "&nbsp;"; main ppf lexbuf }
+  | "``"        { Fmt.string ppf "&ldquo;"; main ppf lexbuf }
+  | "''"        { Fmt.string ppf "&rdquo;"; main ppf lexbuf }
+  | "--"        { exec_macro ppf ~main ~print_arg ~raw_arg ~skip_arg lexbuf "--";
+                  main ppf lexbuf }
+  | "---"       { exec_macro ppf ~main ~print_arg ~raw_arg ~skip_arg lexbuf "---";
+                  main ppf lexbuf }
+  | "^"         { if is_math_mode() then begin
+                    let buf = Lexing.from_string (raw_arg lexbuf) in
+                    Fmt.string ppf "<sup>";
+                    save_state (main ppf) buf;
+                    Fmt.string ppf"</sup>"
+                  end else
+                    Fmt.string ppf "^";
+                  main ppf lexbuf }
+  | "_"         { if is_math_mode() then begin
+                    let buf = Lexing.from_string (raw_arg lexbuf) in
+                    Fmt.string ppf "<sub>";
+                    save_state (main ppf) buf;
+                    Fmt.string ppf"</sub>"
+                  end else
+                    Fmt.string ppf "_";
+                  main ppf lexbuf }
+(* URLs *)
+  | "\\url" { let url = raw_arg lexbuf in
+              if !hevea_url then
+                let text = raw_arg lexbuf in print_hevea_url ppf url text
+              else
+                print_latex_url ppf url;
+              main ppf lexbuf }
+  | "\\" " "
+      { Fmt.string ppf " "; main ppf lexbuf }
+(* General case for environments and commands *)
+  | ("\\begin{" | "\\end{") ['A'-'Z' 'a'-'z' '@']+ "}" |
+    "\\" (['A'-'Z' 'a'-'z' '@']+ '*'? " "? | [^ 'A'-'Z' 'a'-'z'])
+                { let m = chop_last_space (Lexing.lexeme lexbuf) in
+                  exec_macro ppf ~main ~print_arg ~raw_arg ~skip_arg lexbuf m;
+                  main ppf lexbuf }
+(* Nesting of braces *)
+  | '{'         { incr brace_nesting; main ppf lexbuf }
+  | '}'         { if !brace_nesting <= 0
+                  then ()
+                  else begin decr brace_nesting; main ppf lexbuf end }
+(* Default rule for other characters *)
+  | eof         { () }
+  | ['A'-'Z' 'a'-'z']+
+                { if is_math_mode() then Fmt.string ppf "<em>";
+                  Fmt.string ppf(Lexing.lexeme lexbuf);
+                  if is_math_mode() then Fmt.string ppf "</em>";
+                  main ppf lexbuf }
+  | _           { Fmt.char ppf (Lexing.lexeme_char lexbuf 0); main ppf lexbuf }
+
+and indoublequote ppf = parse
+    '"'         { () }
+  | "<"         { Fmt.string ppf "&lt;"; indoublequote ppf lexbuf }
+  | ">"         { Fmt.string ppf "&gt;"; indoublequote ppf lexbuf }
+  | "&"         { Fmt.string ppf "&amp;"; indoublequote ppf lexbuf }
+  | "\\\""      { Fmt.string ppf "\""; indoublequote ppf lexbuf }
+  | "\\\\"      { Fmt.string ppf "\\"; indoublequote ppf lexbuf }
+  | eof         { () }
+  | _           { Fmt.char ppf (Lexing.lexeme_char lexbuf 0);
+                  indoublequote ppf lexbuf }
+
+and inverb ppf = parse
+    "<"         { Fmt.string ppf "&lt;"; inverb ppf lexbuf }
+  | ">"         { Fmt.string ppf "&gt;"; inverb ppf lexbuf }
+  | "&"         { Fmt.string ppf "&amp;"; inverb ppf lexbuf }
+  | eof         { () }
+  | _           { let c = Lexing.lexeme_char lexbuf 0 in
+                  if c == !verb_delim then ()
+                                      else (Fmt.char ppf c; inverb ppf lexbuf) }
+and inverbatim ppf = parse
+    "<"         { Fmt.string ppf "&lt;"; inverbatim ppf lexbuf }
+  | ">"         { Fmt.string ppf "&gt;"; inverbatim ppf lexbuf }
+  | "&"         { Fmt.string ppf "&amp;"; inverbatim ppf lexbuf }
+  | "\\end{verbatim}" { () }
+  | eof         { () }
+  | _           { Fmt.char ppf (Lexing.lexeme_char lexbuf 0);
+                  inverbatim ppf lexbuf }
+
+and rawhtml ppf = parse
+    "\\end{rawhtml}" { () }
+  | eof         { () }
+  | _           { Fmt.char ppf (Lexing.lexeme_char lexbuf 0);
+                  rawhtml ppf lexbuf }
+
+and latexonly = parse
+    "\\end{latexonly}" { () }
+  | eof         { () }
+  | _           { latexonly lexbuf }
+
+and print_arg ppf = parse
+    "{"         { save_nesting (main ppf) lexbuf }
+  | "["         { skip_optional_arg lexbuf; print_arg ppf lexbuf }
+  | " "         { print_arg ppf lexbuf }
+  | eof         { () }
+  | _           { Fmt.char ppf (Lexing.lexeme_char lexbuf 0); main ppf lexbuf }
+
+and skip_arg = parse
+    "{"         { incr brace_nesting; skip_arg lexbuf }
+  | "}"         { decr brace_nesting;
+                  if !brace_nesting > 0 then skip_arg lexbuf }
+  | "["         { if !brace_nesting = 0 then skip_optional_arg lexbuf;
+                  skip_arg lexbuf }
+  | " "         { skip_arg lexbuf }
+  | eof         { () }
+  | _           { if !brace_nesting > 0 then skip_arg lexbuf }
+
+and raw_arg = parse
+  | " " | "\n"  { raw_arg lexbuf }
+  | '{'         { nested_arg lexbuf }
+  | "["         { skip_optional_arg lexbuf; raw_arg lexbuf }
+  | '\\' ['A'-'Z' 'a'-'z']+
+                { Lexing.lexeme lexbuf }
+  | eof         { "" }
+  | _           { Lexing.lexeme lexbuf }
+
+and nested_arg = parse
+    '}'         { "" }
+  | '{'         { let l = nested_arg lexbuf in
+                  "{" ^ l ^ "}" ^ (nested_arg lexbuf) }
+  | eof         { "" }
+  | [^ '{' '}']+{ let x = Lexing.lexeme lexbuf in
+                  x ^ (nested_arg lexbuf)   }
+
+and skip_optional_arg = parse
+    "]"         { () }
+  | eof         { () }
+  | _           { skip_optional_arg lexbuf }
+
+(* ajout personnel: [read_macros] pour lire les macros (La)TeX *)
+
+and read_macros = parse
+  | "\\def" ('\\' ['a'-'z' 'A'-'Z' '@']+ as s) ("#" (['0'-'9']+ as n))?
+      { let b = raw_arg lexbuf in
+        def_macro s n b;
+        read_macros lexbuf }
+  | "\\newcommand" space*
+    "{" ("\\" ['a'-'z' 'A'-'Z']+ as s) "}" ("[" (['0'-'9']+ as n) "]")?
+      { let b = raw_arg lexbuf in
+        def_macro s n b;
+        read_macros lexbuf }
+  | "\\let" ('\\' ['a'-'z' 'A'-'Z' '@']+ as s) '='
+      { let b = raw_arg lexbuf in
+        def_macro s None b;
+        read_macros lexbuf }
+  | eof
+      { () }
+  | _
+      { read_macros lexbuf }

--- a/bibtex/lexer.mll
+++ b/bibtex/lexer.mll
@@ -1,0 +1,159 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+(*i $Id: bibtex_lexer.mll,v 1.19 2010-02-22 07:38:19 filliatr Exp $ i*)
+
+(*s Lexer for BibTeX files. *)
+
+{
+
+open Lexing
+open Parser
+
+let serious = ref false    (* if we are inside a command or not *)
+
+let brace_depth = ref 0
+
+(*s To buffer string literals *)
+
+let buffer = Buffer.create 8192
+
+let reset_string_buffer () =
+  Buffer.reset buffer
+
+let store_string_char c =
+  Buffer.add_char buffer c
+
+let get_stored_string () =
+  let s = Buffer.contents buffer in
+  Buffer.reset buffer;
+  s
+
+let start_delim = ref ' '
+
+let check_delim d = match !start_delim, d with
+  | '{', '}' | '(', ')' -> ()
+  | _ -> failwith "closing character does not match opening"
+
+}
+
+let space = [' ' '\t' '\r' '\n']
+
+rule token = parse
+  | space +
+      { token lexbuf }
+  | '@' space*
+    ([^ ' ' '\t' '\n' '\r' '{' '(']+ as entry_type) space*
+    (('{' | '(') as delim) space*
+       { serious := true;
+         start_delim := delim;
+         match String.lowercase_ascii entry_type with
+           | "string" ->
+               Tabbrev
+           | "comment" ->
+               reset_string_buffer ();
+               comment lexbuf;
+               serious := false;
+               Tcomment (get_stored_string ())
+           | "preamble" ->
+               Tpreamble
+           |  _et ->
+                Tentry (entry_type, key lexbuf)
+       }
+  | '=' { if !serious then Tequal else token lexbuf }
+  | '#' { if !serious then Tsharp else token lexbuf }
+  | ',' { if !serious then Tcomma else token lexbuf }
+  | '{' { if !serious then begin
+            reset_string_buffer ();
+            brace lexbuf;
+            Tstring (get_stored_string ())
+          end else
+            token lexbuf }
+  | ('}' | ')') as d
+        { if !serious then begin
+            check_delim d;
+            serious := false;
+            Trbrace
+          end else
+            token lexbuf }
+  | [^ ' ' '\t' '\n' '\r' '{' '}' '(' ')' '=' '#' ',' '"' '@']+
+      { if !serious then
+          Tident (Lexing.lexeme lexbuf)
+        else
+          token lexbuf }
+  | "\""
+      { if !serious then begin
+          reset_string_buffer ();
+          string lexbuf;
+          Tstring (get_stored_string ())
+        end else
+          token lexbuf }
+  | eof { EOF }
+  | _   { token lexbuf }
+
+and string = parse
+  | '{'
+      { store_string_char '{';
+        brace lexbuf;
+        store_string_char '}';
+        string lexbuf
+      }
+  | '"'
+      { () }
+  | "\\\""
+      { store_string_char '\\';
+        store_string_char '"';
+        string lexbuf}
+  | eof
+      { failwith "unterminated string" }
+  | _
+      { let c = Lexing.lexeme_char lexbuf 0 in
+        store_string_char c;
+        string lexbuf }
+
+and brace = parse
+  | '{'
+      { store_string_char '{';
+        brace lexbuf;
+        store_string_char '}';
+        brace lexbuf
+      }
+  | '}'
+      { () }
+  | eof
+      { failwith "unterminated string" }
+  | _
+      { let c = Lexing.lexeme_char lexbuf 0 in
+        store_string_char c;
+        brace lexbuf }
+
+and key = parse
+  | [^ ' ' '\t' '\n' '\r' ',']+
+    { lexeme lexbuf }
+  | eof
+  | _
+    { raise Parsing.Parse_error }
+
+and comment = parse
+  | '{'
+      { comment lexbuf; comment lexbuf }
+  | [^ '}' '@'] as c
+      { store_string_char c;
+        comment lexbuf }
+  | eof
+      { () }
+  | _
+      { () }

--- a/bibtex/parser.mly
+++ b/bibtex/parser.mly
@@ -1,0 +1,110 @@
+/**************************************************************************/
+/*  bibtex2html - A BibTeX to HTML translator                             */
+/*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   */
+/*                                                                        */
+/*  This software is free software; you can redistribute it and/or        */
+/*  modify it under the terms of the GNU General Public                   */
+/*  License version 2, as published by the Free Software Foundation.      */
+/*                                                                        */
+/*  This software is distributed in the hope that it will be useful,      */
+/*  but WITHOUT ANY WARRANTY; without even the implied warranty of        */
+/*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  */
+/*                                                                        */
+/*  See the GNU General Public License version 2 for more details         */
+/*  (enclosed in the file GPL).                                           */
+/**************************************************************************/
+
+/*
+ * bibtex2html - A BibTeX to HTML translator
+ * Copyright (C) 1997 Jean-Christophe FILLIATRE
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License version 2 for more details
+ * (enclosed in the file GPL).
+ */
+
+/*i $Id: bibtex_parser.mly,v 1.15 2010-02-22 07:38:19 filliatr Exp $ i*/
+
+/*s Parser for BibTeX files. */
+
+%{
+
+  open Types
+
+%}
+
+%token <string> Tident Tstring Tcomment
+%token <string * string> Tentry
+%token Tabbrev Tpreamble Tlbrace Trbrace Tcomma Tequal EOF Tsharp
+
+%start command_list
+%type <Types.t> command_list
+%start command
+%type <Types.command> command
+
+%%
+
+command_list:
+  commands EOF { $1 }
+;
+
+commands:
+   commands command
+     { $2 :: $1 }
+ | /* epsilon */
+     { [] }
+;
+command:
+   Tcomment
+     { Comment $1 }
+ | Tpreamble sharp_string_list Trbrace
+     { Preamble $2 }
+ | Tabbrev Tident Tequal sharp_string_list Trbrace
+     { Abbrev (String.lowercase_ascii $2,$4) }
+ | entry Tcomma comma_field_list Trbrace
+     { let et,key = $1 in Entry (String.lowercase_ascii et, key, $3) }
+;
+
+entry:
+ | Tentry
+     { $1 }
+
+comma_field_list:
+   field Tcomma comma_field_list
+     { $1::$3 }
+ | field
+     { [$1] }
+ | field Tcomma
+     { [$1] }
+;
+field:
+   field_name Tequal sharp_string_list
+     { ($1,$3) }
+ | field_name  Tequal
+     { ($1,[String ""]) }
+;
+field_name:
+   Tident   { String.lowercase_ascii $1 }
+ | Tcomment { "comment" }
+;
+sharp_string_list:
+   atom Tsharp sharp_string_list
+     { $1::$3 }
+ | atom
+     { [$1] }
+;
+atom:
+   Tident
+     { Id (String.lowercase_ascii $1) }
+ | Tstring
+     { String $1 }
+;
+
+%%

--- a/bibtex/types.ml
+++ b/bibtex/types.ml
@@ -1,0 +1,34 @@
+(**************************************************************************)
+(*  bibtex2html - A BibTeX to HTML translator                             *)
+(*  Copyright (C) 1997-2014 Jean-Christophe Filliâtre and Claude Marché   *)
+(*  Copyright (C) 2017 Thomas Gazagnaire                                  *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU General Public                   *)
+(*  License version 2, as published by the Free Software Foundation.      *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(*  See the GNU General Public License version 2 for more details         *)
+(*  (enclosed in the file GPL).                                           *)
+(**************************************************************************)
+
+type entry_type = string
+
+type key = string
+
+type atom =
+  | Id of string
+  | String of string
+
+type command =
+  | Comment of string
+  | Preamble of atom list
+  | Abbrev of string * atom list
+  | Entry  of entry_type * key * (string * atom list) list
+
+type t = command list
+(** [t] is stored as a list. Beware, this in reverse order: the first
+    entry is at the end of the list. This is intentional! *)

--- a/examples/bootstrap/data/test.bib
+++ b/examples/bootstrap/data/test.bib
@@ -1,0 +1,704 @@
+@book{AptOlderog91,
+  author = {K. R. Apt and E.-R. Olderog},
+  title = {Verification of sequential and concurrent programs},
+  publisher = {Springer-Verlag},
+  year = 1991
+}
+@book{Abrial96,
+  author = {J. R. Abrial},
+  title = {The {B}-{B}ook. {A}ssigning programs to meaning},
+  publisher = {Cambridge University Press},
+  year = 1996
+}
+@article{Back81,
+  author = {R. J. R. Back},
+  title = {{On correct refinement of programs}},
+  journal = {{Journal of Computer and Systems Sciences}},
+  year = 1981,
+  volume = 23,
+  number = 1,
+  pages = {{49--68}},
+  month = {August}
+}
+@phdthesis{Barras99,
+  author = {B. Barras},
+  title = {Auto-validation d'un syst{\`e}me de preuves avec familles
+                  inductives},
+  type = {Th{\`e}se de Doctorat},
+  school = {Universit{\'e} Paris~7},
+  year = 1999,
+  month = nov
+}
+@book{Bentley82,
+  author = {J. L. Bentley},
+  title = {{Writing Efficient Programs}},
+  publisher = {Prentice Hall},
+  year = 1982
+}
+@book{Bentley89,
+  author = {J. L. Bentley},
+  title = {{Programming Pearls}},
+  publisher = {{Addison-Wesley}},
+  year = 1989
+}
+@techreport{Berardi93,
+  author = {S. Berardi},
+  title = {{Pruning Simply Typed $\lambda$--terms}},
+  institution = {Turin University},
+  year = {1993},
+  ftp = {ftp://lambda.di.unito.it/pub/stefano/PruningFullPaper.rtf.gz}
+}
+@book{BoyerMoore81,
+  title = {{The Correctness Problem in Computer Science}},
+  publisher = {Academic Press},
+  year = 1981,
+  editor = {R. S. Boyer and J. S. Moore}
+}
+@inproceedings{Chartier98,
+  author = {P. Chartier},
+  title = {{Formalization of B in Isabelle/HOL}},
+  booktitle = {{Proceedings of the Second B International Conference}},
+  publisher = {Springer-Verlag},
+  series = {Lecture Notes in Computer Science},
+  volume = 1393,
+  year = 1998,
+  address = {{Montpellier, France}},
+  month = {April}
+}
+@proceedings{SecondeConferenceB,
+  title = {{Proceedings of the Second B International Conference}},
+  year = 1998,
+  publisher = {Springer-Verlag},
+  series = {Lecture Notes in Computer Science},
+  volume = 1393,
+  address = {{Montpellier, France}},
+  month = {April}
+}
+@inbook{Cousot90,
+  author = {P. Cousot},
+  editor = {J. van Leeuwen},
+  title = {{Handbook of Theoretical Computer Science}},
+  chapter = {{Methods and Logics for Proving Programs}},
+  publisher = {Elsevier Science Publishers B. V.},
+  year = 1990,
+  pages = {{841--993}},
+  volume = {B}
+}
+@incollection{deBruijn80,
+  author = {N.J. de Bruijn},
+  booktitle = {{To H.B. Curry: Essays on Combinatory Logic,
+                        Lambda Calculus and Formalism}},
+  editor = {J. P. Seldin and J. R. Hindley},
+  publisher = {Academic Press},
+  title = {A survey of the project {Automath}},
+  year = 1980
+}
+@book{Dijkstra76,
+  author = {E. W. Dijkstra},
+  title = {{A Discipline of Programming}},
+  publisher = {{Prentice Hall}},
+  year = 1976
+}
+@article{Floyd62,
+  author = {R. W. Floyd},
+  title = {{Algorithm 113: Treesort}},
+  journal = {{Communications of the ACM}},
+  year = 1962,
+  volume = 5,
+  number = 8,
+  month = {August}
+}
+@inproceedings{Floyd67,
+  author = {R. W. Floyd},
+  title = {Assigning meanings to programs},
+  booktitle = {{Mathematical Aspects of Computer Science,
+                  Proceedings of Symposia in Applied Mathematics 19}},
+  editor = {J. T. Schwartz},
+  year = 1967,
+  organization = {American Mathematical Society},
+  address = {Providence},
+  pages = {{19--32}}
+}
+@unpublished{Gimenez99,
+  author = {E. Gim\'enez},
+  title = {{Two Approaches to the Verification of Concurrent Programs
+                  in Coq}},
+  year = 1999,
+  note = {Personal communication},
+  url = {http://pauillac.inria.fr/~gimenez/papers.html}
+}
+@book{GirardLafontTaylor89,
+  author = {J.-Y. Girard and Y. Lafont and P. Taylor},
+  title = {{Proofs and Types}},
+  publisher = {Cambridge University Press},
+  year = 1989
+}
+@article{Goad80,
+  author = {C. Goad},
+  title = {{Proofs as Description of Computation}},
+  journal = {Proceedings of the 5$^{th}$ Conference on Automated
+		  Deduction},
+  year = {1980},
+  publisher = {Springer-Verlag},
+  series = {Lecture Notes in Computer Science},
+  volume = 87
+}
+@inbook{Gordon96,
+  author = {Mike Gordon},
+  title = {{Teaching and Learning Formal Methods}},
+  chapter = {{Teaching hardware and software verification
+                   in a uniform framework}},
+  publisher = {Academic Press},
+  year = 1996,
+  editor = {C. Neville Dean and Michael G. Hinchey},
+  url = {http://www.cl.cam.ac.uk/users/mjcg/papers/SpecVerPaper.ps.gz}
+}
+@book{Gries81,
+  author = {D. Gries},
+  title = {{The Science of Programming}},
+  publisher = {Springer-Verlag},
+  year = 1981
+}
+@phdthesis{Grundy93,
+  author = {Jim Grundy},
+  title = {A Method of Program Refinement},
+  school = {University of Cambridge, Computer Laboratory},
+  address = {New Museums Site, Pembroke Street,
+                     Cambridge CB2 3QG, England},
+  note = {Technical Report 318},
+  month = nov,
+  year = 1993,
+  url = {http://www.cl.cam.ac.uk/ftp/papers/reports/TR318-jg-program-refinement.ps.gz}
+}
+@inproceedings{GuzmanSuarez94,
+  author = {J. Guzm\'an and A. Su\'arez},
+  title = {{An Extended Type System for Exceptions}},
+  booktitle = {{Record of the fifth ACM SIGPLAN workshop on
+		  ML and its Applications}},
+  year = 1994,
+  month = {June},
+  note = {Also appears as Research Report 2265, INRIA,
+                  BP 105 - 78153 Le Chesnay Cedex, France},
+  url = {http://www.ldc.usb.ve/~suarez/PAPERS/except.ps}
+}
+@techreport{Haskell,
+  editors = {J. Peterson and K. Hammond},
+  title = {Haskell 1.4, a non-strict, purely functional language},
+  institution = {Yale University},
+  year = 1997,
+  month = {April}
+}
+@book{Hayes85,
+  author = {I. Hayes},
+  title = {Specification {C}ase {S}tudies},
+  publisher = {Oxford University Computing Laboratory},
+  year = 1985,
+  note = {Technical monograph PRG-46}
+}
+@article{Hoare61,
+  author = {C. A. R. Hoare},
+  title = {{Algorithm 65: Find}},
+  journal = {{Communications of the ACM}},
+  year = 1961,
+  volume = 4,
+  number = 7,
+  pages = {321--322},
+  month = {July}
+}
+@article{Hoare62,
+  author = {C. A. R. Hoare},
+  title = {{Quicksort}},
+  journal = {Computer Journal},
+  month = {April},
+  year = 1962,
+  volume = 5,
+  number = 1,
+  pages = {10--15}
+}
+@article{Hoare69,
+  author = {C. A. R. Hoare},
+  title = {An axiomatic basis for computer programming},
+  journal = {{Communications of the ACM}},
+  year = 1969,
+  volume = 12,
+  number = 10,
+  pages = {576--580,583},
+  note = {Also in \cite{HoareJones89} pages 45--58}
+}
+@article{Hoare71,
+  author = {C. A. R. Hoare},
+  title = {Proof of a program: {\em Find}},
+  journal = {{Communications of the ACM}},
+  year = 1971,
+  volume = 14,
+  number = 1,
+  month = {January},
+  pages = {39--45},
+  note = {Also in \cite{HoareJones89} pages 59--74}
+}
+@book{HoareJones89,
+  author = {C. A. R. Hoare and C. B. Jones},
+  title = {{Essays in Computing Science}},
+  publisher = {Prentice Hall},
+  year = 1989
+}
+@inproceedings{honsell-mason-smith-talcott-92csl,
+  author = {F. Honsell and I. A. Mason and S. F. Smith and C. L. Talcott},
+  year = {1992},
+  title = {{A Theory of Classes for a Functional Language with Effects}},
+  booktitle = {{1992 Annual Conference of the European Association for
+                Computer Science Logic CSL92, San Miniato}},
+  series = {Lecture Notes in Computer Science},
+  publisher = {Springer-Verlag},
+  volume = {702},
+  pages = {309--326}
+}
+@book{JacobsBergetc98,
+  author = {B. Jacobs and J. van den Berg and M. Huisman and
+                  M. van Berkum and U. Hensel and H. Tews},
+  title = {{Reasoning about Java Classes (Preliminary Report).}},
+  publisher = {ACM},
+  year = 1998,
+  pages = {329--340},
+  ps = {http://www.cs.kun.nl/~bart/PAPERS/OOPSLA98.ps.Z}
+}
+@book{JavaSpec,
+  author = {J. Gosling and B. Joy and G. Steele},
+  title = {{The Java Language Specification}},
+  publisher = {Sun Microsystems},
+  year = 1996,
+  series = {Java Series}
+}
+@book{Jones80,
+  author = {C. B. Jones},
+  title = {{Software Development. A rigorous approach}},
+  publisher = {Prentice Hall},
+  year = 1980
+}
+@book{Jones89,
+  author = {C. B. Jones},
+  title = {Systematic {S}oftware {D}evelopment {U}sing {VDM}},
+  publisher = {Prentice Hall},
+  year = 1989
+}
+@book{Jones92,
+  author = {C. B. Jones},
+  title = {{VDM : une méthode rigoureuse pour le développement
+                  du logiciel}},
+  publisher = {Masson},
+  year = 1991,
+  note = {Traduction française de \cite{Jones89}}
+}
+@techreport{JonesDuponcheel93,
+  author = {M. P. Jones and L. Duponcheel},
+  title = {Composing monads},
+  institution = {Yale University},
+  year = {1993},
+  month = {December},
+  number = {YALEU/DCS/RR-1004},
+  type = {Research Report},
+  ftp = {ftp://ftp.cs.nott.ac.uk/nott-fp/reports/yale/RR-1004.ps}
+}
+@inproceedings{JouvelotGifford91,
+  author = {P. Jouvelot and D. K. Gifford},
+  title = {Algebraic {R}econstruction of {T}ypes and {E}ffects},
+  booktitle = {{Proceedings of the 18th ACM Symposium on Principles
+                  of Programming Languages}},
+  month = {January},
+  year = 1991,
+  pages = {303--310},
+  publisher = {ACM}
+}
+@book{KernighanPike99,
+  author = {B. W. Kernighan and R. Pike},
+  title = {{The Practice of Programming}},
+  publisher = {Addison-Wesley},
+  year = 1999
+}
+@book{KernighanRitchie88,
+  author = {B. W. Kernighan and D. M. Ritchie},
+  title = {{The C Programming Language}},
+  publisher = {{Prentice Hall}},
+  year = 1978,
+  edition = {Second}
+}
+@book{Kleene52,
+  author = {S.C. Kleene},
+  publisher = {North-Holland},
+  series = {Bibliotheca Mathematica},
+  title = {Introduction to Metamathematics},
+  year = 1952
+}
+@techreport{Kleymann98,
+  author = {T. Kleymann},
+  title = {{Metatheory of Verification Calculi in LEGO: To What
+                  Extent Does Syntax Matter?}},
+  institution = {LFCS},
+  year = 1998,
+  number = {98-393},
+  month = {September},
+  url = {http://www.dcs.ed.ac.uk/lfcsreps/EXPORT/98/ECS-LFCS-98-393/ECS-LFCS-98-393.ps.gz}
+}
+@book{KnuthV1,
+  author = {D. E. Knuth},
+  title = {{The Art of Computer Programming.
+                   Volume 1: Fundamental Algorithms}},
+  publisher = {{Addison-Wesley}},
+  year = 1968
+}
+@book{KnuthV2,
+  author = {D. E. Knuth},
+  title = {{The Art of Computer Programming.
+                   Volume 2: Seminumerical Algorithms}},
+  publisher = {{Addison-Wesley}},
+  year = 1969
+}
+@book{KnuthV3,
+  author = {D. E. Knuth},
+  title = {{The Art of Computer Programming.
+                   Volume 3: Sorting and Searching}},
+  publisher = {{Addison-Wesley}},
+  year = 1973
+}
+@book{Knuth96,
+  author = {D. E. Knuth},
+  title = {{Selected Papers on Computer Science}},
+  publisher = {CSLI Publications and Cambridge University Press},
+  year = 1996
+}
+@article{KnuthMorrisPratt77,
+  author = {D. E. Knuth and J. H. Morris and V. R. Pratt},
+  title = {{Fast pattern matching in strings}},
+  journal = {{SIAM Journal on Computing}},
+  year = 1977,
+  volume = 6,
+  pages = {323--350}
+}
+@inproceedings{LaunchburyPeytonJones94,
+  author = {J. Launchbury and S. L. Peyton Jones},
+  title = {{Lazy Functional State Threads}},
+  booktitle = {{SIGPLAN Symposium on Programming
+                  Language Design and Implementation (PLDI'94)}},
+  year = 1994,
+  month = {June},
+  pages = {{24--35}},
+  url = {http://www.dcs.gla.ac.uk/fp/papers/lazy-functional-state-threads.ps.Z}
+}
+@article{LeroyPessaux00,
+  author = {X. Leroy and F. Pessaux},
+  title = {Type-based analysis of uncaught exceptions},
+  journal = {{ACM Transactions on Programming Languages and Systems}},
+  year = 2000,
+  number = 22,
+  volume = 2
+}
+@inproceedings{LeroyWeis91,
+  author = {X. Leroy and P. Weis},
+  title = {Polymorphic type inference and assignment},
+  booktitle = {{Proceedings of the 1991 ACM Conference on
+                  Principles of Programming Languages}},
+  pages = {{291--302}},
+  year = 1991,
+  url = {http://pauillac.inria.fr/~xleroy/publi/polymorphic-assignment.dvi.gz}
+}
+@techreport{Lillibridge95,
+  author = {M. Lillibridge},
+  title = {Exceptions {A}re {S}trictly {M}ore {P}owerful {T}han
+		  {Call/CC}},
+  institution = {Carnegie {M}ellon {U}niversity},
+  year = 1995,
+  month = {July},
+  number = 178,
+  ftp = {ftp://reports.adm.cs.cmu.edu/usr/anon/1995/CMU-CS-95-178.ps}
+}
+@inproceedings{MasonTalcott89,
+  author = {I. A. Mason and C. L. Talcott},
+  title = {{Axiomatizing Operational Equivalence in the Presence
+                  of Side Effects}},
+  booktitle = {{Fourth Annual Symposium on Logic in Computer Science}},
+  pages = {284--293},
+  year = 1989,
+  publisher = {IEEE},
+  ps = {http://maths.une.edu.au/~iam/Data/Papers/89lics.ps}
+}
+@article{Milner78,
+  author = {R. Milner},
+  title = {A theory of type polymorphism in programming},
+  journal = {Journal of Computing System Science},
+  year = 1978,
+  volume = 17,
+  pages = {{348--375}}
+}
+@techreport{Moggi89a,
+  author = {E. Moggi},
+  title = {An abstract view of programming languages},
+  institution = {Edinburgh University, Department of Computer
+		  Science},
+  year = 1989,
+  month = {June},
+  number = {ECS-LFCS-90-113},
+  note = {Lecture Notes for course CS 359, Stanford University},
+  url = {http://www.disi.unige.it/person/MoggiE/ftp/abs-view.dvi.gz}
+}
+@inproceedings{Moggi89c,
+  author = {E. Moggi},
+  title = {Computational lambda-calculus and monads},
+  booktitle = {{IEEE Symposium on Logic in Computer Science}},
+  year = {1989},
+  url = {http://www.disi.unige.it/person/MoggiE/ftp/lc88.dvi.gz}
+}
+@article{Moggi91,
+  author = {E. Moggi},
+  title = {{Notions of computations and monads}},
+  journal = {{Information and Computation}},
+  year = 1991,
+  volume = 93,
+  number = 1
+}
+@book{Monin96,
+  author = {J.-F. Monin},
+  title = {{Comprendre les méthodes formelles}},
+  publisher = {Masson},
+  year = 1996
+}
+@inproceedings{MoggiPalumbo99,
+  author = {E. Moggi and F. Palumbo},
+  title = {{Monadic Encapsulation of Effects: a Revised Approach}},
+  booktitle = {{Third International Workshop on
+                   Higher Order Operational Techniques in Semantics}},
+  year = 1999,
+  ps = {http://www.disi.unige.it/person/MoggiE/ftp/hoots99.ps.gz}
+}
+@book{Morgan90,
+  author = {C. C. Morgan},
+  title = {{Programming from Specifications}},
+  publisher = {Prentice Hall},
+  year = 1990
+}
+@techreport{MorrisPratt70,
+  author = {J. H. Morris and V. R. Pratt},
+  title = {{A Linear Pattern Matching Algorithm}},
+  institution = {Computing Center, University of California, Berkeley},
+  year = 1970,
+  number = 40
+}
+@unpublished{Munoz98,
+  author = {C. Mu{\~{n}}oz},
+  title = {{Supporting the B-method in PVS: An
+             Approach to the Abstract Machine Notation in Type Theory}},
+  note = {Submitted to FSE-98},
+  year = 1998,
+  url = {http://www.csl.sri.com/~munoz/Papers/pbs.ps.gz}
+}
+@article{OHearnReynolds97,
+  author = {P. W. O'Hearn and J. C. Reynolds},
+  title = {From {A}lgol to {P}olymorphic {L}inear {L}ambda-calculus},
+  journal = {{Journal of the ACM}},
+  year = 1997,
+  month = {April},
+  note = {To appear},
+  ftp = {ftp://ftp.dcs.qmw.ac.uk/lfp/ohearn/AlgolToPolyLin.ps}
+}
+@incollection{Paulin91,
+  author = {C. Paulin-Mohring},
+  title = {R\'ealisabilit\'e et extraction de programmes},
+  booktitle = {Logique et informatique : une introduction},
+  publisher = {INRIA},
+  year = 1991,
+  pages = {163--180}
+}
+@incollection{Reif95,
+  author = {W. Reif},
+  title = {{The KIV-approach to software verification}},
+  booktitle = {{KORSO: Methods, Languages, and Tools for the
+                Construction of Correct Software -- Final Report}},
+  year = 1995,
+  editor = {M. Broy and S. J\"ahnichen},
+  publisher = {Springer-Verlag},
+  series = {Lecture Notes in Computer Science},
+  volume = 1009,
+  ftp = {ftp://ftp.informatik.uni-ulm.de/pub/PM/kiv/papers/kiv-approach.ps}
+}
+@incollection{KIVCaseStudies,
+  author = {T. Fuchß and W. Reif and G. Schellhorn and K. Stenzel},
+  title = {{Three Selected Case Studies in Verification}},
+  booktitle = {{KORSO: Methods, Languages, and Tools for the
+                Construction of Correct Software -- Final Report}},
+  year = 1995,
+  editor = {M. Broy and S. J\"ahnichen},
+  publisher = {Springer-Verlag},
+  series = {Lecture Notes in Computer Science},
+  volume = 1009,
+  ftp = {ftp://ftp.informatik.uni-ulm.de/pub/PM/kiv/papers/three-selected-case-studies.ps.gz}
+}
+@inproceedings{Schreiber97,
+  author = {T. Schreiber},
+  title = {{Auxiliary Variables and Recursive Procedures}},
+  booktitle = {{TAPSOFT'97: Theory and Practice of Software Development}},
+  publisher = {Springer-Verlag},
+  volume = 1214,
+  series = {Lecture Notes in Computer Science},
+  year = 1997,
+  month = {April},
+  pages = {697--711},
+  ftp = {ftp://ftp.dcs.ed.ac.uk/pub/tms/tapsoft97-with-page-numbers.ps.gz}
+}
+@book{Sedgewick78,
+  author = {R. Sedgewick},
+  title = {Quicksort},
+  publisher = {Garland, New York},
+  year = 1978,
+  note = {Also appeared as the author's Ph.D. dissertation,
+                  Stanford University, 1975}
+}
+@book{Sedgewick88,
+  author = {R. Sedgewick},
+  title = {Algorithms},
+  publisher = {{Addison-Wesley}},
+  year = 1988
+}
+@inproceedings{SemmelrothSabry99,
+  author = {M. Semmelroth and A. Sabry},
+  title = {{Monadic Encapsulation in ML}},
+  booktitle = {{ACM SIGPLAN International Conference on Functional
+                  Programming}},
+  publisher = {ACM},
+  year = 1999,
+  ps = {http://www.cs.uoregon.edu/~sabry/papers/monadic-encap.ps}
+}
+@inproceedings{Steele94,
+  author = {G. L. Steele Jr.},
+  title = {Building interpreters by composing monads},
+  booktitle = {{Symposium on Principles of Programming Languages}},
+  year = {1994},
+  month = {January},
+  publisher = {Association for Computing Machinery},
+  pages = {472--492}
+}
+@article{Takayama91,
+  author = {Y. Takayama},
+  title = {{Extraction of Redundancy-free Programs from
+		  Constructive Natural Deduction Proofs}},
+  journal = {Journal of Symbolic Computation},
+  year = {1991},
+  volume = {1},
+  number = {12},
+  pages = {29-69}
+}
+@article{TalpinJouvelot92,
+  author = {J.-P. Talpin and P. Jouvelot},
+  title = {{Polymorphic Type, Region and Effect Inference}},
+  journal = {Journal of Functional Programming},
+  year = 1992,
+  volume = 2,
+  number = 3,
+  publisher = {Cambridge University Press},
+  ftp = {ftp://cri.ensmp.fr/pub/Papers/Talpin/jfp92.ps.Z}
+}
+@article{TalpinJouvelot94,
+  author = {J.-P. Talpin and P. Jouvelot},
+  title = {{The Type and Effect discipline}},
+  journal = {Information and Computation},
+  year = 1994,
+  volume = 111,
+  number = 2,
+  pages = {245-296},
+  publisher = {Academic Press},
+  ftp = {ftp://cri.ensmp.fr/pub/Papers/Talpin/lics92.ps.Z}
+}
+@phdthesis{Tofte87,
+  author = {M. Tofte},
+  title = {{Operational Semantics and Polymorphic Type Inference}},
+  school = {University of Edinburgh},
+  year = 1987
+}
+@inproceedings{Tolmach98,
+  author = {A. Tolmach},
+  title = {{Optimizing ML Using a Hierarchy of Monadic Types}},
+  booktitle = {{Types in Compilation '98 Workshop}},
+  pages = {97--113},
+  year = 1998,
+  address = {Kyoto, Japan},
+  month = {March},
+  publisher = {Springer-Verlag},
+  series = {Lecture Notes in Computer Science},
+  volume = 1473,
+  ps = {http://www.cs.pdx.edu/~apt/monad_types_paper.ps}
+}
+@inproceedings{Wadler92a,
+  author = {P. Wadler},
+  title = {Monads for functional programming},
+  booktitle = {{Proceedings of the Marktoberdorf Summer School on
+		  Program Design Calculi}},
+  year = {1992},
+  month = {August}
+}
+@article{Wadler92b,
+  author = {P. Wadler},
+  title = {Comprehending monads},
+  journal = {Mathematical Structures in Computer Science},
+  year = {1992},
+  pages = {461--493}
+}
+@inproceedings{Wadler92c,
+  author = {D. J. King and P. Wadler},
+  title = {Combining monads},
+  booktitle = {{Glasgow Workshop on Functional Programming}},
+  year = {1992},
+  month = {July},
+  publisher = {Springer-Verlag Workshops in Computing Series}
+}
+@incollection{Wadler93,
+  author = {P. Wadler},
+  title = {Monads for functional programming},
+  booktitle = {{Program Design Calculi}},
+  publisher = {Springer Verlag},
+  year = 1993,
+  editor = {M. Broy},
+  series = {NATO ASI Series}
+}
+@inproceedings{Wadler98,
+  author = {P. Wadler},
+  title = {{The marriage of effects and monads}},
+  booktitle = {{International Conference on Functional Programming}},
+  year = 1998,
+  publisher = {ACM},
+  address = {Baltimore},
+  month = {September},
+  pages = {63--74}
+}
+@article{Williams64,
+  author = {J. W. J. Williams},
+  title = {{Algorithm 232: Heapsort}},
+  journal = {{Communications of the ACM}},
+  year = 1964,
+  volume = 7,
+  number = 6,
+  month = {June}
+}
+@book{Winskel93,
+  author = {G. Winskel},
+  title = {The formal semantics of programming languages},
+  publisher = {The MIT Press},
+  year = 1993
+}
+@inproceedings{Wright92,
+  author = {A. K. Wright},
+  title = {Typing {R}eferences by {E}ffect {I}nference},
+  booktitle = {{European Symposium on Programming}},
+  year = 1992,
+  publisher = {Springer-Verlag},
+  series = {Lecture Notes in Computer Science},
+  volume = 582,
+  pages = {473--491},
+  month = {February}
+}
+@article{WrightFelleisen94,
+  author = {A. K. Wright and M. Felleisen},
+  title = {A syntactic approach to type soundness},
+  journal = {Information and Computation},
+  volume = 115,
+  year = 1994,
+  pages = {38--94},
+  url = {http://www.cs.rice.edu/CS/PLT/Publications/ic94-wf.ps.gz}
+}

--- a/examples/bootstrap/data/two.md
+++ b/examples/bootstrap/data/two.md
@@ -1,3 +1,8 @@
 ## Links
 
 Haha
+
+{{ for i in notes }}
+**{{ i.title }}** are in __{{ i.loc }}__.
+
+{{ endfor }}

--- a/examples/bootstrap/pages/papers.html
+++ b/examples/bootstrap/pages/papers.html
@@ -7,8 +7,9 @@ title: Papers
 <div class="container">
   <div class="row">
     <div class="col">
-      {{ for i in notes }}
-      <p><b>{{ i.title }}</b> are in {{ i.loc }}.
+      {{ for i in test | -id }}
+      <p>[{{ i.id }}]<b>{{ i.title }}</b>. {{ i.author }}.
+         <em>{{ i.year }}<em>
       {{ endfor }}
     </div>
   </div>

--- a/src/ast.mli
+++ b/src/ast.mli
@@ -7,9 +7,11 @@ type t =
 and loop = {
   var   : string;
   map   : string;
-  order : string option;
+  order : order option;
   body  : t;
 }
+
+and order = [`Up | `Down] * string
 
 val pp: t Fmt.t
 val dump: t Fmt.t

--- a/src/jbuild
+++ b/src/jbuild
@@ -2,7 +2,7 @@
 
 (library
   ((name        template)
-   (libraries   (logs astring omd fmt))))
+   (libraries   (logs astring omd fmt bibtex))))
 
 (ocamllex (lexer))
 (menhir ((modules (parser))))

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -43,8 +43,8 @@ let syntax_error s = raise (Error s)
 }
 
 let digit = ['0'-'9']
-let alpha = ['a'-'z' 'A'-'Z' '-' '_']
-let id = alpha (alpha | digit)*
+let alpha = ['a'-'z' 'A'-'Z']
+let id = alpha (alpha | digit | '-' | '_')*
 let var = id ('.' id)*
 let newline = '\r' | '\n' | "\r\n"
 let white = [' ' '\t']+
@@ -63,6 +63,7 @@ and program t = parse
   | "endfor" { ENDFOR }
   | "in"     { IN }
   | "|"      { PIPE }
+  | "-"      { MINUS }
   | var      { VAR (Lexing.lexeme lexbuf) }
   | eof      { syntax_error "unclosed tag" }
 

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -3,7 +3,7 @@ open Ast
 %}
 
 %token <string> VAR DATA
-%token FOR IN ENDFOR PIPE
+%token FOR IN ENDFOR PIPE MINUS
 %token EOF
 
 %start main
@@ -17,10 +17,13 @@ main:
 expr:
   | VAR  { Var $1 }
   | DATA { Data $1 }
-  | FOR VAR IN VAR PIPE VAR exprs ENDFOR
-         { For { var=$2; map=$4; order=Some $6; body=$7 } }
-  | FOR VAR IN VAR exprs ENDFOR
-         { For { var=$2; map=$4; order=None; body=$5 } }
+  | FOR VAR IN VAR ordering exprs ENDFOR
+         { For { var=$2; map=$4; order=$5; body=$6 } }
+
+ordering:
+  |                { None }
+  | PIPE VAR       { Some (`Up  , $2) }
+  | PIPE MINUS VAR { Some (`Down, $3) }
 
 exprs:
   | list(expr) { Seq $1 }

--- a/src/template.mli
+++ b/src/template.mli
@@ -50,9 +50,11 @@ module Ast: sig
   and loop = {
     var   : string;
     map   : string;
-    order : string option;
+    order : order option;
     body  : t;
   }
+
+  and order = [`Up | `Down] * string
 
   val pp: t Fmt.t
   val dump: t Fmt.t


### PR DESCRIPTION
Import a bunch of files from bibtex2html (+ various code cleanups) as these are not installed as a library.

The current bibtex support seems to work ok (see the [example](https://github.com/samoht/ramen/blob/bibtex/examples/bootstrap/pages/papers.html)) but more polishing is needed before that stuff being really useful enough. Some normalisation between the various entry types would probably be the shortest route for now on.