### PR TITLE
More consistent naming of collections built from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ The body can contain templates of the form:
 
   When reading files in the `data/` directory, Ramen always removes
   the file extensions to build the variable names:
-  the contents of `foo/a.html` is available as `foo.a`. In some cases (see
+  the contents of `foo/a.html` is available as `foo.a.body`.
+  In some cases (see
   [bellow](https://github.com/samoht/ramen#supported-file-extensions) for details),
-  the contents is available in a `body` sub-field, e.g. the contents of
-  `foo/a.md` is available as `foo.a.body`.
+  the contents is pre-processed.
 
   Raw data can also contains the `{{ .. }}` quotations. They are
   expanded recursively by Ramen.

--- a/src/template.ml
+++ b/src/template.ml
@@ -536,7 +536,7 @@ let parse_file ~file v =
   | ".md"   -> parse_md ~file v
   | _       ->
     let k = Filename.(remove_extension @@ basename file) in
-    data k v
+    kollection k (context_of_page @@ parse_page ~file v)
 
 let read_dir f dir =
   Log.debug (fun l -> l "Reading directory %s" dir);

--- a/src/template.ml
+++ b/src/template.ml
@@ -310,7 +310,8 @@ let eval_var ~file ~context ~errors v =
     | Id h::t ->
       find ctx (fun c ->
           collection h (fun ctx ->
-              var (Context.v ctx) k t
+              var (Context.v ctx) k t >|= fun (p, v) ->
+              h :: p, v
             ) c
         ) h
     | App (h, p)::t ->
@@ -324,7 +325,8 @@ let eval_var ~file ~context ~errors v =
                 List.filter (fun {k; _} -> not (List.mem_assoc k p)) ctx
               in
               let ctx = List.rev_map (param h) p @ ctx in
-              var (Context.v ctx) k t
+              var (Context.v ctx) k t >|= fun (p, v) ->
+              h :: p, v
             ) c
         ) h
   and param h (k, v) = match v with

--- a/test/test.ml
+++ b/test/test.ml
@@ -170,18 +170,19 @@ module Data = struct
       "toto.yml" , "foo: bar\nbar: toto\n";
       "zzzz/bar.x", "test test test test";
     ] in
+    let file f x = Template.(collection f [data "body" x]) in
     let ctx = Template.(Context.v [
-        data "bar" @@ List.assoc "bar.x" files;
-        data "foo" @@ List.assoc "foo.x" files;
+        file "bar" @@ List.assoc "bar.x" files;
+        file "foo" @@ List.assoc "foo.x" files;
         collection "fooo" [
-          data "bar" "test test test test";
+          file "bar" "test test test test";
         ];
         collection "toto" [
           data "foo" "bar";
           data "bar" "toto";
         ];
         collection "zzzz" [
-          data "bar" "test test test test";
+          file "bar" "test test test test";
         ];
       ])
     in


### PR DESCRIPTION
Now all files `foo.*` of the form:

```
k_1: v_1
...
k_n: v_n
---
contents
```

are converted to:
```
foo.k_1 -> v_1
...
foo.k_n -> v_n
foo.body -> f(contents)
```
where `f` is usually the identity function but is (markdown -> HTML) if the file extension is `.md`