### PR TITLE
Simplify the language syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,16 @@ The body can contain templates of the form:
   Raw data can also contains the `{{ .. }}` quotations. They are
   expanded recursively by Ramen.
 
-- **loops**: `{{ for i in var }} <body> {{ endfor }}`: Ramen
+- **loops**: `{{ for i in var do }} <body> {{ done }}`: Ramen
   expands the body for each entry in the collection `var`.
 
   For instance, if `data/foo` contains two files `data/foo/a.md` and
   `data/foo/b.md` which contains `toto` and `titi` respectively, then:
 
   ```html
-  {{ for i in foo }}
+  {{ for i in foo do }}
   Hello {{ i }}.
-  {{ endfor }}
+  {{ done }}
   ```
   is equivalent to:
   ```html
@@ -116,12 +116,13 @@ The body can contain templates of the form:
   start or end conditions, for instance:
 
   ```html
-  {{ for i in foo }}
-  {{ if i = foo.first }}
-  Hello first {{ i }}.
-  {{ else }}
-  Hello {{ i }}
-  {{ endif }}
+  {{ for i in foo do }}
+    {{ if (i = foo.first) }}
+    Hello first {{ i }}.
+    {{ else }}
+    Hello {{ i }}
+    {{ fi }}
+  {{ done }}
   ```
 
   Moreover, every collection can be seen as a doubly-linked list, where elements
@@ -129,18 +130,28 @@ The body can contain templates of the form:
   snippet is equivalent to:
 
   ```html
-  {{ for i in foo }}
-  {{ if !i.prev }}
-  Hello first {{ i }}.
-  {{ else }}
-  Hello {{ i }}
-  {{ endif }}
+  {{ for i in foo do }}
+    {{ if (!i.prev) }}
+    Hello first {{ i }}.
+    {{ else }}
+    Hello {{ i.prev.next }}
+    {{ fi }}
+  {{ done }}
   ```
 
-- **conditions**: `{{ if cond_1 }} <body_1> ... {{ elif cond_n }} <body_n> {{
-  endif }}`. Ramen picks the first `<body_i>` such that `cond_i` is
-  satisfied (or it uses an empty string if none of the conditions
-  are true). Conditions expressions are composed by:
+  The order in which the iteration is done is by default the order in which
+  the collection is built (lexical order, order in which items appears in a
+  file, etc). It is possible to control the iteration order by using the
+  built-in function `rev(..)` and `sort(..,<id>)` where `id` is the key in
+  which to base the sort.
+
+- **conditions**: `{{ if (cond_1) }} <body_1> ... {{ elif (cond_n) }} <body_n>
+  {{ else }} <body_x> {{ fi }}`.
+  Ramen picks the first `<body_i>` such that `cond_i` is
+  satisfied or uses `<body_x>` otherwise (or an empty string if none of the
+  conditions are true and the else clause is missing).
+
+  Conditions expressions the compososition of:
     - single variables: `var`;
     - equalities: `var_1 = var_2` or `var_1 = 'string'`
     - inequalities: `var_1 != var_2` or `var_1 != 'string'`
@@ -152,11 +163,11 @@ The body can contain templates of the form:
   For instance:
 
   ```html
-  {{ if i.title && (i = site.page) }}
+  {{ if (i.title && i = site.page) }}
     <div class="nav active">{{i.title}}</div>
-  {{ elif i.title }}
+  {{ elif (i.title) }}
     <div class"nav">{{i.title}}<div>
-  {{ endif }}
+  {{ fi }}
   ```
 
 - **dictionaries**: `{{ xxx.[VAR].yyy }}` evaluates to `xxx.v.yyy`
@@ -165,13 +176,14 @@ The body can contain templates of the form:
   For example, if you have two collections `books` and `people`,
   you can cross-reference them using:
   ````html
-  {{for i in books}}
+  {{for i in books do}}
     <div class="book">
       <div class="title">{{i.title}}</div>
       <div class="author">{{people.[i.author].name}}</div>
     </div>
-  {{endfor}}
+  {{done}}
   ````
+
 - **fonctions**: `{{ VAR(k_1: v_1, ..., k_n: v_n) }}` this is similar
   to evaluating `VAR` in the context where `k_1`,...,`k_n` are bound
   to `v_1`,...`v_n`. For instance, this could be used to parametrize

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -9,20 +9,23 @@ type t =
   | Seq of t list
 
 and loop = {
-  var   : string;
-  map   : var;
-  order : order option;
-  body  : t;
+  for_ : string;
+  in_  : iter;
+  do_  : t;
 }
 
+and iter =
+  | Base of var
+  | Rev of iter
+  | Sort of iter * string
+
 and cond = {
-  test : test;
+  if_  : test;
   then_: t;
-  else_: cond option;
+  else_: t option;
 }
 
 and test =
-  | True
   | Paren of test
   | Def of var
   | Op of var_or_text * op * var_or_text
@@ -53,18 +56,21 @@ let rec pp ppf = function
   | For l  -> pp_loop ppf l
 
 and pp_loop ppf t =
-  let o ppf = match t.order with
-    | None            -> Fmt.string ppf ""
-    | Some (`Up  , s) -> Fmt.pf ppf " | %s" s
-    | Some (`Down, s) -> Fmt.pf ppf " | -%s" s
-  in
-  Fmt.pf ppf "{{ for %s in %a%t }}%a{{ endfor }}" t.var pp_var t.map o pp t.body
+  Fmt.pf ppf "{{ for %s in %a do }}%a{{ done }}" t.for_ pp_iter t.in_ pp t.do_
+
+and pp_iter ppf = function
+  | Base v     -> pp_var ppf v
+  | Rev t      -> Fmt.pf ppf "rev(%a)" pp_iter t
+  | Sort (f,x) -> Fmt.pf ppf "sort(%a, %s)" pp_iter f x
 
 and pp_cond ppf t =
-  Fmt.pf ppf "{{ if %a }}%a%a" pp_test t.test pp t.then_ pp_elif t.else_
+  Fmt.pf ppf "{{ if %a }}%a%a{{ fi }}" pp_test t.if_ pp t.then_ pp_else t.else_
+
+and pp_else ppf = function
+  | None   -> Fmt.string ppf ""
+  | Some t -> Fmt.pf ppf "{{ else }}%a" pp t
 
 and pp_test ppf = function
-  | True        -> Fmt.string ppf ""
   | Paren x     -> Fmt.pf ppf "(%a)" pp_test x
   | Def x       -> pp_var ppf x
   | Neg x       -> Fmt.pf ppf "!%a" pp_test x
@@ -75,11 +81,6 @@ and pp_test ppf = function
 and pp_op ppf = function
   | `Eq  -> Fmt.string ppf "="
   | `Neq -> Fmt.string ppf "!="
-
-and pp_elif ppf = function
-  | None   -> Fmt.string ppf "{{ endif }}"
-  | Some t ->
-    Fmt.pf ppf "{{ elif %a }}%a%a" pp_test t.test pp t.then_ pp_elif t.else_
 
 and pp_var ppf t = Fmt.(list ~sep:(unit ".") pp_id) ppf t
 
@@ -104,15 +105,18 @@ let rec dump ppf = function
   | For l  -> Fmt.pf ppf "@[<hov 2>For %a@]" dump_loop l
 
 and dump_loop ppf t =
-  Fmt.pf ppf "{var=%s;@ map=%a;@ order=%a;@ body=%a}"
-    t.var dump_var t.map Fmt.(Dump.option dump_order) t.order dump t.body
+  Fmt.pf ppf "{for_=%s;@ in_=%a;@ do_=%a}" t.for_ dump_iter t.in_ dump t.do_
+
+and dump_iter ppf = function
+  | Base var   -> Fmt.pf ppf "@[<hov 2>Base %a@]" dump_var var
+  | Rev t      -> Fmt.pf ppf "@[<hov 2>Rev %a@]" dump_iter t
+  | Sort (f,x) -> Fmt.pf ppf "@[<hov 2>Sort (%a,@ %s)@]" dump_iter f x
 
 and dump_cond ppf t =
   Fmt.pf ppf "{test=%a;@ then_=%a;@ else_=%a}"
-   dump_test t.test dump t.then_ Fmt.(Dump.option dump_cond) t.else_
+   dump_test t.if_ dump t.then_ Fmt.(Dump.option dump) t.else_
 
 and dump_test ppf = function
-  | True       -> Fmt.pf ppf "True"
   | Paren t    -> Fmt.pf ppf "@[<hov 2>Paren %a@]" dump_test t
   | Def t      -> Fmt.pf ppf "@[<hov 2>Def %a@]" dump_var t
   | Neg t      -> Fmt.pf ppf "@[<hov 2>Neg %a@]" dump_test t
@@ -125,10 +129,6 @@ and dump_test ppf = function
 and dump_op ppf = function
   | `Eq  -> Fmt.string ppf "`Eq"
   | `Neq -> Fmt.string ppf "`Neq"
-
-and dump_order ppf (t, s) = match t with
-  | `Up   -> Fmt.string ppf s
-  | `Down -> Fmt.pf ppf "-%s" s
 
 and dump_var ppf t = Fmt.(Dump.list dump_id) ppf t
 
@@ -160,26 +160,25 @@ let rec equal x y =
   | Text _, _ | Var _, _ | Seq _, _ | For _, _ | If _, _ -> false
 
 and equal_loop x y =
-  String.equal x.var y.var
-  && equal_var x.map y.map
-  && equal_order x.order y.order
-  && equal x.body y.body
+  String.equal x.for_ y.for_
+  && equal_iter x.in_ y.in_
+  && equal x.do_ y.do_
 
-and equal_order x y = match x, y with
-  | None      , None         -> true
-  | Some (a, x), Some (b, y) ->  a = b && String.equal x y
-  | _ -> false
+and equal_iter x y = match x, y with
+  | Base x    , Base y     -> equal_var x y
+  | Rev x     , Rev y      -> equal_iter x y
+  | Sort (a,b), Sort (c,d) -> equal_iter a c && String.equal b d
+  | Base _, _ | Rev _, _ | Sort _, _ -> false
 
 and equal_cond x y =
-  equal_test x.test y.test
+  equal_test x.if_ y.if_
   && equal x.then_ y.then_
   && match x.else_, y.else_ with
   | None  , None   -> true
-  | Some x, Some y -> equal_cond x y
+  | Some x, Some y -> equal x y
   | _ -> false
 
 and equal_test x y = match x, y with
-  | True      , True       -> true
   | Paren a   , Paren b    -> equal_test a b
   | Neg a     , Neg b      -> equal_test a b
   | Op (a,x,b), Op (c,y,d) ->
@@ -187,8 +186,7 @@ and equal_test x y = match x, y with
   | And (a, b), And (c, d) -> equal_test a c && equal_test b d
   | Or (a, b) , Or (c ,d)  -> equal_test a c && equal_test b d
   | Def x    , Def y     -> equal_var x y
-  | True, _ | Paren _, _ | Neg _, _ | Op _, _ | Def _, _ | And _, _
-  | Or _, _ -> false
+  | Paren _, _ | Neg _, _ | Op _, _ | Def _, _ | And _, _ | Or _, _ -> false
 
 and equal_op = (=)
 

--- a/src/ast.mli
+++ b/src/ast.mli
@@ -6,20 +6,23 @@ type t =
   | Seq of t list
 
 and loop = {
-  var   : string;
-  map   : var;
-  order : order option;
-  body  : t;
+  for_: string;
+  in_ : iter;
+  do_ : t;
 }
 
+and iter =
+  | Base of var
+  | Rev of iter
+  | Sort of iter * string
+
 and cond = {
-  test : test;
+  if_  : test;
   then_: t;
-  else_: cond option;
+  else_: t option;
 }
 
 and test =
-  | True
   | Paren of test
   | Def of var
   | Op of var_or_text * op * var_or_text

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -72,11 +72,13 @@ and program t = parse
   | '\''     { string t lexbuf }
   | '.'      { DOT }
   | "for"    { FOR }
-  | "endfor" { ENDFOR }
+  | "in"     { IN }
+  | "do"     { DO }
+  | "done"   { DONE }
   | "if"     { IF }
   | "elif"   { ELIF }
   | "else"   { ELSE }
-  | "endif"  { ENDIF }
+  | "fi"     { FI }
   | "&&"     { AND }
   | "||"     { OR }
   | ":"      { COLON }
@@ -84,13 +86,12 @@ and program t = parse
   | "="      { EQ }
   | "!"      { BANG }
   | "!="     { NEQ }
-  | "in"     { IN }
-  | "|"      { PIPE }
-  | "-"      { MINUS }
   | "["      { LBRA }
   | "]"      { RBRA }
   | "("      { LPAR }
   | ")"      { RPAR }
+  | "sort"   { SORT }
+  | "rev"    { REV }
   | var      { let v = Lexing.lexeme lexbuf in p t "VAR %S" v; VAR v }
   | eof      { unclosed_tag () }
 

--- a/src/template.ml
+++ b/src/template.ml
@@ -48,6 +48,7 @@ let pp_file = Fmt.(styled `Underline string)
 let pp_key = Fmt.(styled `Bold string)
 let string_of_var = Fmt.to_to_string Ast.pp_var
 let pp_ids = Fmt.(styled `Bold @@ list ~sep:(unit ".") string)
+let string_of_ids = Fmt.to_to_string pp_ids
 
 (* ENTRIES *)
 
@@ -298,38 +299,29 @@ module Error = struct
 
 end
 
-let custom_compare d x y =
+let custom_compare x y =
   let ix = try Some (int_of_string x) with Failure _ -> None in
   let iy = try Some (int_of_string y) with Failure _ -> None in
-  let r = match ix, iy with
-    | Some x, Some y -> compare x y
-    | _ -> String.compare x y
-  in
-  match d with
-  | `Up   -> r
-  | `Down -> -r
+  match ix, iy with
+  | Some x, Some y -> compare x y
+  | _              -> String.compare x y
 
-let sort ~file ~context ~errors loop x y =
+let sort ~file ~context ~errors ~loop ~id x y =
   let default = String.compare x.k y.k in
   let loc = loc ~file ~context (For loop) in
-  let with_order (d, order) =
-    match x.v, y.v with
-    | Data _           , Data _            -> default
-    | Collection (_, x), Collection (_, y) ->
-      (match Context.find x order, Context.find y order with
-       | Some (Data x), Some (Data y) -> custom_compare d x y
-       | None, _ | _, None  ->
-         Error.add errors (err_invalid_order order loc);
-         default
-       | Some (Collection _), _ | _, Some (Collection _) ->
-         Error.add errors (err_data_is_needed order loc);
-         default
-      )
-    | _ -> default
-  in
-  match loop.Ast.order with
-  | None       -> default
-  | Some order -> with_order order
+  match x.v, y.v with
+  | Data _           , Data _            -> default
+  | Collection (_, x), Collection (_, y) ->
+    (match Context.find x id, Context.find y id with
+     | Some (Data x), Some (Data y) -> custom_compare x y
+     | None, _ | _, None  ->
+       Error.add errors (err_invalid_order id loc);
+       default
+     | Some (Collection _), _ | _, Some (Collection _) ->
+       Error.add errors (err_data_is_needed id loc);
+       default
+    )
+  | _ -> default
 
 let empty = Ast.Text ""
 
@@ -408,43 +400,6 @@ let eval_var ~file ~context ~errors v =
   r
 
 
-let eval_test ~file ~context ~errors t =
-  let open Ast in
-  let var_is_defined v =
-    let errors = Error.v () in
-    match eval_var ~file ~context ~errors v with
-    | None   -> false
-    | Some _ -> true
-  in
-  let var_or_text = function
-    | `Text d -> Data d
-    | `Var v  ->
-      match eval_var ~file ~context ~errors v with
-      | None   -> Data "<undefined>"
-      | Some v -> snd v
-  in
-  let rec aux k x =
-    match x with
-    | True       -> true
-    | Paren x    -> aux k x
-    | Def x      -> k (var_is_defined x)
-    | Neg x      -> aux (fun x -> k (not x)) x
-    | And (x, y) -> aux (fun x -> aux (fun y -> x && y) y) x
-    | Or (x, y)  -> aux (fun x -> aux (fun y -> x || y) y) x
-    | Op (x,o,y) ->
-      let x = var_or_text x in
-      let y = var_or_text y in
-      let equal = match o with
-        | `Eq  -> (fun x y -> equal_value x y)
-        | `Neq -> (fun x y -> not (equal_value x y))
-      in
-      k (equal x y)
-
-  in
-  let b = aux (fun x -> x) t in
-  Log.debug (fun l -> l "eval_test: %a => %b" Ast.pp_test t b);
-  b
-
 (* add .next and .prev to each element of the collection *)
 let link_items c =
   let empty = Data "" in
@@ -487,6 +442,67 @@ let link_items c =
       e
     ) r
 
+let eval_loop ~file ~context ~errors loop =
+  let open Ast in
+  let loc = loc ~file ~context (For loop) in
+  let (>|=) x f = match x with
+    | None        -> None
+    | Some (n, l) -> Some (n, f l)
+  in
+  let rec aux k = function
+    | Rev t  -> aux (fun x -> x >|= List.rev) t
+    | Base v ->
+      (match eval_var ~file ~context ~errors v with
+       | Some (_, Collection (_, [])) | None -> k None
+       | Some (p, Collection (_, c)) -> k (Some (p, c))
+       | Some (p, Data _) ->
+         Error.add errors (err_collection_is_needed (string_of_ids p) loc);
+         k None)
+    | Sort (f, id) ->
+      aux (fun l ->
+          l >|= fun l ->
+          let sort = sort ~file ~context ~errors ~loop ~id in
+          List.sort sort l
+        ) f
+  in
+  aux (fun l -> l >|= link_items) loop.in_
+
+let eval_test ~file ~context ~errors t =
+  let open Ast in
+  let var_is_defined v =
+    let errors = Error.v () in
+    match eval_var ~file ~context ~errors v with
+    | None   -> false
+    | Some _ -> true
+  in
+  let var_or_text = function
+    | `Text d -> Data d
+    | `Var v  ->
+      match eval_var ~file ~context ~errors v with
+      | None   -> Data "<undefined>"
+      | Some v -> snd v
+  in
+  let rec aux k x =
+    match x with
+    | Paren x    -> aux k x
+    | Def x      -> k (var_is_defined x)
+    | Neg x      -> aux (fun x -> k (not x)) x
+    | And (x, y) -> aux (fun x -> aux (fun y -> x && y) y) x
+    | Or (x, y)  -> aux (fun x -> aux (fun y -> x || y) y) x
+    | Op (x,o,y) ->
+      let x = var_or_text x in
+      let y = var_or_text y in
+      let equal = match o with
+        | `Eq  -> (fun x y -> equal_value x y)
+        | `Neq -> (fun x y -> not (equal_value x y))
+      in
+      k (equal x y)
+
+  in
+  let b = aux (fun x -> x) t in
+  Log.debug (fun l -> l "eval_test: %a => %b" Ast.pp_test t b);
+  b
+
 let eval ~file ~context ?(failfast=false) contents =
   let open Ast in
   let errors = Error.v ~failfast () in
@@ -509,20 +525,9 @@ let eval ~file ~context ?(failfast=false) contents =
     | For l -> loop ctx k l
 
   and loop ctx k l =
-    match eval_var ~file ~context:ctx ~errors l.map with
-    | None             -> k empty
-    | Some (p, Data _) ->
-      err err_collection_is_needed ~context:ctx (For l) "%a" pp_ids p;
-      k empty
-    | Some (_, Collection (_, [])) -> k empty
-    | Some (p, Collection (_, c))   ->
-      let entries = match l.order with
-        | None   -> c
-        | Some _ ->
-          let sort = sort ~file ~context:ctx ~errors l in
-          List.sort sort c
-      in
-      let entries = link_items entries in
+    match eval_loop ~file ~context:ctx ~errors l with
+    | None              -> k empty
+    | Some (p, entries) ->
       assert (List.length entries > 0);
       let first = { k="first"; v = (List.hd entries).v } in
       let last  = { k="last" ; v = (List.hd (List.rev entries)).v } in
@@ -530,9 +535,9 @@ let eval ~file ~context ?(failfast=false) contents =
       let ctx = Context.insert ctx p last in
       let bodies =
         List.map (fun { k; v } ->
-            Log.debug (fun d -> d "unrolling %s=%s" l.var k);
-            let ctx = Context.add ctx { k = l.var; v } in
-            ctx, l.body
+            Log.debug (fun d -> d "unrolling %s=%s" l.for_ k);
+            let ctx = Context.add ctx { k = l.for_; v } in
+            ctx, l.do_
           ) entries
       in
       Acc.list (fun l (ctx, body) ->
@@ -543,11 +548,11 @@ let eval ~file ~context ?(failfast=false) contents =
         ) bodies
 
   and cond ctx k c =
-    if eval_test ~file ~context:ctx ~errors c.test
+    if eval_test ~file ~context:ctx ~errors c.if_
     then t ctx (fun x -> k x) c.then_
     else match c.else_ with
       | None   -> k empty
-      | Some c -> cond ctx k c
+      | Some c -> t ctx k c
 
   and var ctx k v =
     let replace p d =

--- a/src/template.ml
+++ b/src/template.ml
@@ -487,8 +487,8 @@ let eval_test ~file ~context ~errors t =
     | Paren x    -> aux k x
     | Def x      -> k (var_is_defined x)
     | Neg x      -> aux (fun x -> k (not x)) x
-    | And (x, y) -> aux (fun x -> aux (fun y -> x && y) y) x
-    | Or (x, y)  -> aux (fun x -> aux (fun y -> x || y) y) x
+    | And (x, y) -> aux (fun x -> if not x then k false else aux k y) x
+    | Or (x, y)  -> aux (fun x -> if x then k true else aux k y) x
     | Op (x,o,y) ->
       let x = var_or_text x in
       let y = var_or_text y in

--- a/test/test.ml
+++ b/test/test.ml
@@ -232,9 +232,9 @@ module For = struct
     let template =
       Fmt.strf {|
 Test:
-   {{ for i in toto }}
+   {{ for i in toto do }}
    %s
-   {{ endfor }}
+   {{ done }}
 |} (one "{{ i.name }}" "{{ i.age }}")
       |> Template.Ast.(parse ~file)
     in
@@ -255,9 +255,9 @@ Test:
     let template =
       Fmt.strf {|
 Test:
- {{ for i in toto | name }}
+ {{ for i in sort(toto, name) do }}
    %s
- {{ endfor }}
+ {{ done }}
 |} (one "{{ i.name }}" "{{ i.age }}")
       |> Template.Ast.(parse ~file)
     in
@@ -288,23 +288,23 @@ Test:
 
   let first () =
     test [
-      "{{ for i in toto if (i = toto.first) i.name endif endfor }}",
+      "{{ for i in toto do if (i = toto.first) i.name fi done }}",
       "Monique"
     ]
 
   let last () =
     test [
-      "{{ for i in toto if (i = toto.last) i.name endif endfor }}",
+      "{{ for i in toto do if (i = toto.last) i.name fi done }}",
       "Jean Valjean"
     ]
 
   let meta () =
     test [
-      "{{ for i in toto if i.next i.next.prev.name endif endfor }}",
+      "{{ for i in toto do if (i.next) i.next.prev.name fi done }}",
       "Monique";
-      "{{ for i in toto if i.prev i.prev.next.name endif endfor }}",
+      "{{ for i in toto do if (i.prev) i.prev.next.name fi done }}",
       "Jean Valjean";
-      "{{ for i in toto.bar if i.prev i.prev.next endif endfor }}",
+      "{{ for i in toto.bar do if (i.prev) i.prev.next fi done }}",
       "422";
     ]
 end
@@ -334,40 +334,40 @@ module If = struct
 
   let simple () =
     test [
-      "Hello {{ if toto.name }}world!{{ endif }}", "Hello world!";
-      "Hi {{ if calvi }}Jean{{ endif }}"         , "Hi ";
+      "Hello {{ if (toto.name) }}world!{{ fi }}", "Hello world!";
+      "Hi {{ if (calvi) }}Jean{{ fi }}"         , "Hi ";
     ]
 
   let many () =
     test [
-      "{{if toto.name && foo}}hello!{{endif}}" , "hello!";
-      "{{if calvi}}Jean{{elif foo}}yo{{endif}}", "yo";
+      "{{if (toto.name && foo)}}hello!{{fi}}" , "hello!";
+      "{{if (calvi)}}Jean{{elif (foo)}}yo{{fi}}", "yo";
     ]
 
   let equal () =
     test [
-      "{{if (foo = bar)}}hello!{{endif}}"         , "hello!";
-      "{{if (foo = bar) && toto.name}}yo{{endif}}", "yo";
+      "{{if (foo = bar)}}hello!{{fi}}"         , "hello!";
+      "{{if (foo = bar && toto.name)}}yo{{fi}}", "yo";
     ]
 
   let neg () =
     test [
-      "{{if !foo}}hello!{{endif}}"          , "";
-      "{{if (foo != toto.name)}}yo{{endif}}", "yo";
+      "{{if (!foo)}}hello!{{fi}}"          , "";
+      "{{if (foo != toto.name)}}yo{{fi}}", "yo";
     ]
 
   let else_ () =
     test [
-      "{{if !foo}}hello!{{else}}By!{{endif}}", "By!";
-      "{{if foo}}hello!{{else}}By!{{endif}}" , "hello!";
+      "{{if (!foo)}}hello!{{else}}By!{{fi}}", "By!";
+      "{{if (foo)}}hello!{{else}}By!{{fi}}" , "hello!";
     ]
 
   let text () =
     test [
-      "{{if (foo = 'x')}}hello!{{endif}}" , "hello!";
-      "{{if (foo = 'y')}}hello!{{endif}}" , "";
-      "{{if ('x' != foo)}}hello!{{endif}}", "";
-      "{{if (foo != 'y')}}hello!{{endif}}", "hello!";
+      "{{if (foo = 'x')}}hello!{{fi}}" , "hello!";
+      "{{if (foo = 'y')}}hello!{{fi}}" , "";
+      "{{if ('x' != foo)}}hello!{{fi}}", "";
+      "{{if (foo != 'y')}}hello!{{fi}}", "hello!";
     ]
 end
 
@@ -410,7 +410,7 @@ module Get = struct
         Alcotest.(check ast) (string_of_int i) (f y) (eval @@ f x)
       )[
       "Hello {{ people.[truc.one.owner].name }}", "Hello Jean Valjean";
-      "{{for i in truc}}{{people.[i.owner].name}} {{endfor}}",
+      "{{for i in truc do}}{{people.[i.owner].name}} {{done}}",
       "Jean Valjean Toto ";
     ]
 


### PR DESCRIPTION
It is now possible to write something like:

```
for i in rev(sort(entries, mame)) do
  if (!i.prev && i.name && (i.name = 'toto' || i.name = 'titi'))
    ...
  elif (i.title)
    ...
  else
    ...
  fi
done
```